### PR TITLE
fix(chat): improve interaction reliability and safety

### DIFF
--- a/app/core/turn_context.py
+++ b/app/core/turn_context.py
@@ -36,6 +36,7 @@ TRANSITIONS: dict[tuple[TurnState, str], TurnState] = {
     (TurnState.STREAM, "error"): TurnState.FINALIZE,
     (TurnState.STREAM, "cancelled"): TurnState.FINALIZE,
     (TurnState.EXECUTE, "ok"): TurnState.FEEDBACK,
+    (TurnState.EXECUTE, "error"): TurnState.FINALIZE,
     (TurnState.EXECUTE, "cancelled"): TurnState.FINALIZE,
     (TurnState.FEEDBACK, "continue"): TurnState.STREAM,
     (TurnState.FEEDBACK, "max_turns"): TurnState.WRAP_UP,

--- a/app/i18n/en.py
+++ b/app/i18n/en.py
@@ -162,6 +162,9 @@ EN: dict[str, str] = {
     "chat.error.hint404": "\n\nTip: check the default model's API URL and model name in settings (current model: {model})",
     "chat.error.hint401": "\n\nTip: invalid API key, please re-enter it in settings",
     "chat.emptyMessage": "(empty message)",
+    "chat.action.copy": "Copy",
+    "chat.action.regenerate": "Regenerate",
+    "chat.action.edit": "Edit",
 
     # ── Pin window (pinned screenshot) ──
     "pin.copy": "📋 Copy",

--- a/app/i18n/en.py
+++ b/app/i18n/en.py
@@ -140,6 +140,9 @@ EN: dict[str, str] = {
     "input.placeholder": "Type a message… (Enter to send, Shift+Enter for newline)",
     "input.send": "Send",
     "input.cancel": "Cancel",
+    "input.editing": "Editing message",
+    "input.cancelEdit": "Cancel edit",
+    "input.cancelling": "Stopping…",
 
     # ── Session panel ──
     "session.title": "Sessions",

--- a/app/i18n/zh.py
+++ b/app/i18n/zh.py
@@ -162,6 +162,9 @@ ZH: dict[str, str] = {
     "chat.error.hint404": "\n\n提示：请在设置中检查默认模型的 API 地址和模型名称（当前模型: {model}）",
     "chat.error.hint401": "\n\n提示：API Key 无效，请在设置中重新填写",
     "chat.emptyMessage": "（空消息）",
+    "chat.action.copy": "复制",
+    "chat.action.regenerate": "重新生成",
+    "chat.action.edit": "编辑",
 
     # ── 贴图窗口（钉住的截图）──
     "pin.copy": "📋 复制",

--- a/app/i18n/zh.py
+++ b/app/i18n/zh.py
@@ -140,6 +140,9 @@ ZH: dict[str, str] = {
     "input.placeholder": "输入消息… (Enter 发送，Shift+Enter 换行)",
     "input.send": "发送",
     "input.cancel": "取消",
+    "input.editing": "正在编辑消息",
+    "input.cancelEdit": "取消编辑",
+    "input.cancelling": "正在停止…",
 
     # ── 会话面板 ──
     "session.title": "会话",

--- a/app/tools/fetch_url.py
+++ b/app/tools/fetch_url.py
@@ -72,6 +72,11 @@ def _check_url_safety(url: str) -> tuple[bool, str]:
             ip = ipaddress.ip_address(info[4][0])
         except ValueError:
             continue
+        # IPv4-mapped IPv6（如 ::ffff:127.0.0.1）在原生网段比对时不会命中内网段，
+        # 但 OS 解析后仍会连到对应 IPv4，先归一化再判断，避免 SSRF 绕过。
+        mapped = getattr(ip, "ipv4_mapped", None)
+        if mapped is not None:
+            ip = mapped
         for network in _BLOCKED_NETWORKS:
             if ip in network:
                 return False, t("tool.fetch_url.msg.blocked_internal", hostname=hostname, ip=ip)

--- a/app/tools/read_file.py
+++ b/app/tools/read_file.py
@@ -10,11 +10,15 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from app.tools.base import BuiltinTool
 from app.tools.schema import Num, Str, tool_params
+from app.tools._path_utils import resolve_safe
 from app.i18n import t
+
+if TYPE_CHECKING:
+    from app.tools.context import ToolContext
 
 # 默认最大读取字符数
 _MAX_DEFAULT = 50_000
@@ -22,6 +26,13 @@ _MAX_DEFAULT = 50_000
 
 class ReadFileTool(BuiltinTool):
     """本地文件读取工具。"""
+
+    def __init__(self, workspace: Path):
+        self._workspace = workspace.resolve()
+
+    @classmethod
+    def create(cls, ctx: "ToolContext") -> "ReadFileTool":
+        return cls(workspace=ctx.workspace)
 
     @property
     def name(self) -> str:
@@ -51,8 +62,10 @@ class ReadFileTool(BuiltinTool):
         if not raw_path:
             return {"status": "error", "data": {"message": "file_path is required"}}
 
-        # 展开 ~ 为用户主目录
-        path = Path(raw_path).expanduser()
+        # 限制在 workspace 内，避免 AI 读取任意系统文件（.ssh、凭据等）
+        path, err = resolve_safe(raw_path, self._workspace)
+        if err:
+            return {"status": "error", "data": {"message": err}}
 
         if not path.exists():
             return {"status": "error", "data": {"message": t("tool.read_file.msg.not_found", path=path)}}

--- a/app/ui/chat_session_controller.py
+++ b/app/ui/chat_session_controller.py
@@ -67,6 +67,10 @@ class ChatSessionController(QObject):
         self._workers: dict[str, AgentLoop] = {}
         self._cancelled_workers: list[AgentLoop] = []
         self._session_live: dict[str, dict] = {}
+        # 待生效的编辑：{sid: 截断下标}。点「编辑」只回填输入框、不动历史；
+        # 用户真正重发时才在 submit 里按此下标截断旧轮，替换为新消息。
+        # 若用户放弃重发（切会话等），原对话原样保留。
+        self._pending_edit: dict[str, int] = {}
         self._current_ai_bubble = None
         self._current_ai_msg: Message | None = None
         self._current_ai_text = ""
@@ -311,6 +315,10 @@ class ChatSessionController(QObject):
             self._current_ai_bubble = None
 
     def switch_session(self, sid: str):
+        # 切走即放弃未重发的编辑：待生效下标只对发起编辑时的那条消息有效。
+        prev = self._current_session_id
+        if prev is not None and prev != sid:
+            self._pending_edit.pop(prev, None)
         self._current_ai_bubble = None
         self._current_ai_msg = None
         self._current_ai_text = ""
@@ -357,6 +365,14 @@ class ChatSessionController(QObject):
             attachments=attachments,
         )
 
+        # 若本次发送来自「编辑重发」，先截断被编辑消息及其后的旧对话，
+        # 再追加新消息——此刻才真正改动历史，放弃重发则原样保留。
+        edit_idx = self._pending_edit.pop(sid, None)
+        if edit_idx is not None and edit_idx < len(self._sessions.get(sid).messages):
+            session = self._sessions.get(sid)
+            session.messages = session.messages[:edit_idx]
+            self._chat.load_session(session.messages)
+
         self._sessions.add_message(sid, user_msg)
         self._chat.add_message(user_msg)
         self._session_panel.update_title(sid, self._sessions.get(sid).title)
@@ -372,6 +388,16 @@ class ChatSessionController(QObject):
         self._current_ai_msg = ai_msg
         self._current_ai_bubble = None
         self._current_ai_text = ""
+
+        self._begin_turn(sid)
+
+    def _begin_turn(self, sid: str):
+        """启动一轮 AgentLoop：装配 live 状态、压缩历史、起 worker。
+
+        submit() 与 regenerate_last() 共用：两者都在会话尾部已有一条空的
+        assistant 占位消息、并设好 live 状态后调用此方法，避免重复的
+        worker 装配逻辑。
+        """
         self._input.set_running(True)
         self._tool_status.hide()
         self._chat.start_typing()
@@ -397,6 +423,79 @@ class ChatSessionController(QObject):
         self._workers[sid] = worker
         self._connect_worker(sid, worker)
         worker.start()
+
+    # ── 消息级操作：复制 / 重新生成 / 编辑重发（仅作用于最后一轮）─────────────
+    def copy_reply(self, message: Message):
+        """把某条消息的原始文本复制到剪贴板。
+
+        复制成功的反馈由气泡按钮自身切换成对号图标呈现（见 MessageBubble），
+        这里不再弹通知。
+        """
+        from PyQt6.QtWidgets import QApplication
+
+        text = message.content or ""
+        if not text:
+            return
+        QApplication.clipboard().setText(text)
+
+    def regenerate_last(self, _message: Message | None = None):
+        """重新生成最后一轮 AI 回复：截断到最后一条用户消息之后，重跑。"""
+        sid = self._current_session_id
+        if not sid or sid in self._workers:
+            return
+        session = self._sessions.get(sid)
+        if session is None:
+            return
+        # 找到最后一条用户消息的位置，丢弃其后的所有 assistant/tool 消息。
+        last_user_idx = self._last_user_index(session.messages)
+        if last_user_idx is None:
+            return
+        session.messages = session.messages[: last_user_idx + 1]
+
+        ai_msg = Message(role=MessageRole.ASSISTANT, content="")
+        self._sessions.add_message(sid, ai_msg)
+        self._session_live[sid] = {
+            "ai_msg": ai_msg,
+            "ai_text": "",
+            "first_chunk_sent": False,
+        }
+        self._current_ai_msg = ai_msg
+        self._current_ai_bubble = None
+        self._current_ai_text = ""
+        self._chat.load_session(session.messages[:-1])
+        self._begin_turn(sid)
+
+    def edit_last(self, message: Message):
+        """编辑最后一条用户消息：把原文与附件回填输入框，等用户重发。
+
+        非破坏性：只登记一个「待生效编辑」下标并回填输入框，不立刻删历史。
+        用户真正重发（submit）时才按此下标截断旧轮、替换为新消息；若用户
+        放弃重发（清空输入框、切会话等），原对话原样保留。
+        """
+        sid = self._current_session_id
+        if not sid or sid in self._workers:
+            return
+        session = self._sessions.get(sid)
+        if session is None:
+            return
+        last_user_idx = self._last_user_index(session.messages)
+        if last_user_idx is None:
+            return
+        user_msg = session.messages[last_user_idx]
+        self._pending_edit[sid] = last_user_idx
+
+        if user_msg.attachments:
+            self._input.add_pending_attachments(list(user_msg.attachments))
+        self._input.set_text(user_msg.content or "")
+        self._input.focus()
+
+    @staticmethod
+    def _last_user_index(messages: list) -> int | None:
+        """返回最后一条 user 消息的下标，没有则 None。"""
+        for i in range(len(messages) - 1, -1, -1):
+            if messages[i].role == MessageRole.USER:
+                return i
+        return None
 
     def _build_hooks(self) -> list:
         """构建本次 turn 的生命周期 hook（安全审计 + 评测埋点）。

--- a/app/ui/chat_session_controller.py
+++ b/app/ui/chat_session_controller.py
@@ -434,7 +434,7 @@ class ChatSessionController(QObject):
             if active_id and self._sessions.get(active_id) is not None:
                 return active_id
         session = self._sessions.create(
-            title=READING_SESSION_TITLE, source=SOURCE_READING
+            title=reading_session_title(), source=SOURCE_READING
         )
         self.set_active_reading(session.id)
         return session.id

--- a/app/ui/chat_session_controller.py
+++ b/app/ui/chat_session_controller.py
@@ -65,12 +65,11 @@ class ChatSessionController(QObject):
 
         self._current_session_id: str | None = None
         self._workers: dict[str, AgentLoop] = {}
-        self._cancelled_workers: list[AgentLoop] = []
+        self._cancelling_sessions: set[str] = set()
         self._session_live: dict[str, dict] = {}
-        # 待生效的编辑：{sid: 截断下标}。点「编辑」只回填输入框、不动历史；
-        # 用户真正重发时才在 submit 里按此下标截断旧轮，替换为新消息。
-        # 若用户放弃重发（切会话等），原对话原样保留。
-        self._pending_edit: dict[str, int] = {}
+        # 待生效编辑：{sid: user message id}。普通发送永不截断历史；只有
+        # submit_edit() 再次确认目标仍是最后一条 user 消息后才执行替换。
+        self._pending_edit: dict[str, str] = {}
         self._current_ai_bubble = None
         self._current_ai_msg: Message | None = None
         self._current_ai_text = ""
@@ -283,42 +282,29 @@ class ChatSessionController(QObject):
     def cancel_worker(self, sid: str | None = None, *, mark_cancelled: bool = True):
         if sid is None:
             sid = self._current_session_id
-        if not sid:
+        if not sid or sid in self._cancelling_sessions:
             return
-        worker = self._workers.pop(sid, None)
-        live = self._session_live.pop(sid, None)
+        worker = self._workers.get(sid)
+        live = self._session_live.get(sid)
         if worker is None:
             return
 
+        self._cancelling_sessions.add(sid)
         if mark_cancelled and live:
             self._mark_live_message_cancelled(sid, live)
 
-        try:
-            worker.disconnect()
-        except RuntimeError:
-            pass
-        self._cancelled_workers.append(worker)
-        try:
-            worker.finished.connect(
-                lambda _=None, w=worker: self._release_cancelled_worker(w)
-            )
-        except (AttributeError, RuntimeError):
-            pass
         worker.cancel()
-
         if sid == self._current_session_id:
             self._chat.stop_typing()
             self._tool_status.hide()
-            self._input.set_running(False)
-            self._input.focus()
-            self._current_ai_msg = None
-            self._current_ai_bubble = None
+            self._input.set_cancelling(True)
 
     def switch_session(self, sid: str):
         # 切走即放弃未重发的编辑：待生效下标只对发起编辑时的那条消息有效。
         prev = self._current_session_id
         if prev is not None and prev != sid:
-            self._pending_edit.pop(prev, None)
+            if self._pending_edit.pop(prev, None) is not None:
+                self._input.end_edit(clear=True)
         self._current_ai_bubble = None
         self._current_ai_msg = None
         self._current_ai_text = ""
@@ -337,11 +323,15 @@ class ChatSessionController(QObject):
             last = self._chat.last_bubble()
             if last and not last.is_user:
                 self._current_ai_bubble = last
+                self._current_ai_bubble.bind_message(live["ai_msg"])
             else:
                 self._current_ai_bubble = None
-            self._input.set_running(True)
-            if not live.get("first_chunk_sent"):
-                self._chat.start_typing()
+            if sid in self._cancelling_sessions:
+                self._input.set_cancelling(True)
+            else:
+                self._input.set_running(True)
+                if not live.get("first_chunk_sent"):
+                    self._chat.start_typing()
         else:
             self._input.set_running(False)
 
@@ -352,26 +342,41 @@ class ChatSessionController(QObject):
         self._input.add_pending_attachments(attachments)
 
     def submit(self, text: str):
+        """Append a normal user turn; pending edit state is never consumed as edit."""
+        sid = self._current_session_id
+        if not sid or sid in self._workers:
+            return
+        if self._pending_edit.pop(sid, None) is not None:
+            self._input.end_edit(clear=False)
+        self._submit_turn(sid, text)
+
+    def submit_edit(self, text: str) -> None:
+        """Replace the last user turn only when the recorded message still matches."""
+        sid = self._current_session_id
+        if not sid or sid in self._workers:
+            return
+        target_id = self._pending_edit.pop(sid, None)
+        session = self._sessions.get(sid)
+        edit_idx = self._message_index(session.messages, target_id) if session else None
+        last_user_idx = self._last_user_index(session.messages) if session else None
+        if edit_idx is not None and edit_idx == last_user_idx:
+            session.messages = session.messages[:edit_idx]
+            self._chat.load_session(session.messages)
+        self._submit_turn(sid, text)
+
+    def cancel_edit(self) -> None:
         sid = self._current_session_id
         if not sid:
             return
-        if sid in self._workers:
-            return
+        self._pending_edit.pop(sid, None)
 
+    def _submit_turn(self, sid: str, text: str) -> None:
         attachments = self._input.take_pending_attachments()
         user_msg = Message(
             role=MessageRole.USER,
             content=text,
             attachments=attachments,
         )
-
-        # 若本次发送来自「编辑重发」，先截断被编辑消息及其后的旧对话，
-        # 再追加新消息——此刻才真正改动历史，放弃重发则原样保留。
-        edit_idx = self._pending_edit.pop(sid, None)
-        if edit_idx is not None and edit_idx < len(self._sessions.get(sid).messages):
-            session = self._sessions.get(sid)
-            session.messages = session.messages[:edit_idx]
-            self._chat.load_session(session.messages)
 
         self._sessions.add_message(sid, user_msg)
         self._chat.add_message(user_msg)
@@ -466,12 +471,7 @@ class ChatSessionController(QObject):
         self._begin_turn(sid)
 
     def edit_last(self, message: Message):
-        """编辑最后一条用户消息：把原文与附件回填输入框，等用户重发。
-
-        非破坏性：只登记一个「待生效编辑」下标并回填输入框，不立刻删历史。
-        用户真正重发（submit）时才按此下标截断旧轮、替换为新消息；若用户
-        放弃重发（清空输入框、切会话等），原对话原样保留。
-        """
+        """Enter explicit edit mode for the current session's last user message."""
         sid = self._current_session_id
         if not sid or sid in self._workers:
             return
@@ -482,15 +482,27 @@ class ChatSessionController(QObject):
         if last_user_idx is None:
             return
         user_msg = session.messages[last_user_idx]
-        self._pending_edit[sid] = last_user_idx
-
-        if user_msg.attachments:
-            self._input.add_pending_attachments(list(user_msg.attachments))
-        self._input.set_text(user_msg.content or "")
+        if user_msg.id != message.id:
+            return
+        self._pending_edit[sid] = user_msg.id
+        self._input.begin_edit(
+            user_msg.content or "", list(user_msg.attachments)
+        )
         self._input.focus()
 
     @staticmethod
-    def _last_user_index(messages: list) -> int | None:
+    def _message_index(
+        messages: list[Message], message_id: str | None
+    ) -> int | None:
+        if message_id is None:
+            return None
+        for i, message in enumerate(messages):
+            if message.id == message_id:
+                return i
+        return None
+
+    @staticmethod
+    def _last_user_index(messages: list[Message]) -> int | None:
         """返回最后一条 user 消息的下标，没有则 None。"""
         for i in range(len(messages) - 1, -1, -1):
             if messages[i].role == MessageRole.USER:
@@ -548,21 +560,37 @@ class ChatSessionController(QObject):
             self.cancel_worker(sid, mark_cancelled=False)
 
     def _connect_worker(self, sid: str, worker: AgentLoop):
-        worker.text_chunk.connect(lambda delta, s=sid: self._on_text_chunk(s, delta))
+        worker.text_chunk.connect(
+            lambda delta, s=sid, w=worker: self._on_text_chunk(s, delta, w)
+        )
         worker.tool_event.connect(
-            lambda call_id, phase, payload, s=sid: self._on_tool_event(
-                s, call_id, phase, payload
+            lambda call_id, phase, payload, s=sid, w=worker: self._on_tool_event(
+                s, call_id, phase, payload, w
             )
         )
         worker.need_input.connect(
-            lambda call_id, tool_name, params, s=sid: self._on_need_input(
-                s, call_id, tool_name, params
+            lambda call_id, tool_name, params, s=sid, w=worker: self._on_need_input(
+                s, call_id, tool_name, params, w
             )
         )
-        worker.new_turn.connect(lambda turn_count, s=sid: self._on_new_turn(s, turn_count))
-        worker.done.connect(lambda info, s=sid: self._on_done(s, info))
+        worker.new_turn.connect(
+            lambda turn_count, s=sid, w=worker: self._on_new_turn(s, turn_count, w)
+        )
+        worker.done.connect(
+            lambda info, s=sid, w=worker: self._on_done(s, info, w)
+        )
+        worker.finished.connect(
+            lambda s=sid, w=worker: self._on_worker_finished(s, w)
+        )
 
-    def _on_text_chunk(self, sid: str, delta: str):
+    def _is_current_worker(self, sid: str, worker: AgentLoop | None) -> bool:
+        return worker is None or self._workers.get(sid) is worker
+
+    def _on_text_chunk(
+        self, sid: str, delta: str, worker: AgentLoop | None = None
+    ):
+        if not self._is_current_worker(sid, worker) or sid in self._cancelling_sessions:
+            return
         live = self._session_live.get(sid)
         if live is None:
             return
@@ -584,20 +612,33 @@ class ChatSessionController(QObject):
         except RuntimeError:
             self._current_ai_bubble = None
 
-    def _on_tool_event(self, sid: str, call_id: str, phase: str, payload: dict):
+    def _on_tool_event(
+        self,
+        sid: str,
+        call_id: str,
+        phase: str,
+        payload: dict,
+        worker: AgentLoop | None = None,
+    ):
+        if not self._is_current_worker(sid, worker):
+            return
         session = self._sessions.get(sid)
+        live = self._session_live.get(sid)
+        is_cancelling = sid in self._cancelling_sessions
         if phase == "start":
             tool_name = payload["name"]
             params = payload["params"]
-            if session and session.messages:
+            if live and live.get("ai_msg"):
                 tool_call = ToolCall(
                     id=call_id,
                     name=tool_name,
                     arguments=params,
                     status="running",
                 )
-                session.messages[-1].tool_calls.append(tool_call)
-            if sid != self._current_session_id:
+                live["ai_msg"].tool_calls.append(tool_call)
+                if is_cancelling:
+                    self._sessions.save_session(sid)
+            if is_cancelling or sid != self._current_session_id:
                 return
             # 工具执行期间保持亮条转动——执行本身就是「任务进行中」，
             # 不要 stop_typing，否则长耗时工具（如 websearch）期间界面没有
@@ -617,6 +658,7 @@ class ChatSessionController(QObject):
                         if tool_call.id == call_id:
                             tool_call.result = result
                             tool_call.status = result.get("status", "success")
+                            self._sessions.save_session(sid)
                             break
             if sid != self._current_session_id:
                 return
@@ -629,9 +671,14 @@ class ChatSessionController(QObject):
         call_id: str,
         tool_name: str,
         param_names: list,
+        source_worker: AgentLoop | None = None,
     ):
         worker = self._workers.get(sid)
-        if worker is None:
+        if (
+            worker is None
+            or (source_worker is not None and worker is not source_worker)
+            or sid in self._cancelling_sessions
+        ):
             return
         if sid == self._current_session_id:
             dialog = ManualParamsDialog(tool_name, param_names, self._parent)
@@ -640,7 +687,11 @@ class ChatSessionController(QObject):
             params = {}
         worker.supply_input(params)
 
-    def _on_new_turn(self, sid: str, turn_count: int):
+    def _on_new_turn(
+        self, sid: str, turn_count: int, worker: AgentLoop | None = None
+    ):
+        if not self._is_current_worker(sid, worker) or sid in self._cancelling_sessions:
+            return
         ai_msg = Message(role=MessageRole.ASSISTANT, content="")
         self._sessions.add_message(sid, ai_msg)
         live = self._session_live.get(sid)
@@ -653,10 +704,17 @@ class ChatSessionController(QObject):
         self._current_ai_msg = ai_msg
         self._current_ai_text = ""
         if self._current_ai_bubble:
+            self._current_ai_bubble.bind_message(ai_msg)
             self._current_ai_bubble.clear_text()
         self._chat.start_typing()
 
-    def _on_done(self, sid: str, info: dict):
+    def _on_done(
+        self, sid: str, info: dict, worker: AgentLoop | None = None
+    ):
+        if not self._is_current_worker(sid, worker):
+            return
+        if sid in self._cancelling_sessions:
+            return
         live = self._session_live.get(sid)
         ok = info.get("ok", True)
         error_msg = info.get("error")
@@ -743,11 +801,43 @@ class ChatSessionController(QObject):
             return f"{text}\n\n{marker}"
         return marker
 
-    def _release_cancelled_worker(self, worker: AgentLoop):
-        try:
-            self._cancelled_workers.remove(worker)
-        except ValueError:
-            pass
+    def _on_worker_finished(self, sid: str, worker: AgentLoop) -> None:
+        if self._workers.get(sid) is not worker:
+            return
+        if sid not in self._cancelling_sessions:
+            return
+        live = self._session_live.get(sid)
+        if live:
+            self._finalize_cancelled_tools(sid, live)
+        self._sessions.save_session(sid)
+        self._workers.pop(sid, None)
+        self._session_live.pop(sid, None)
+        self._cancelling_sessions.discard(sid)
+        if sid != self._current_session_id:
+            return
+        self._chat.stop_typing()
+        self._tool_status.hide()
+        self._input.set_cancelling(False)
+        self._input.set_running(False)
+        self._input.focus()
+        self._current_ai_msg = None
+        self._current_ai_bubble = None
+
+    def _finalize_cancelled_tools(self, sid: str, live: dict) -> None:
+        ai_msg = live.get("ai_msg")
+        if ai_msg is None:
+            return
+        result = {
+            "status": "error",
+            "data": {"message": _cancelled_marker()},
+        }
+        for tool_call in ai_msg.tool_calls:
+            if tool_call.status not in ("pending", "running"):
+                continue
+            tool_call.result = dict(result)
+            tool_call.status = "error"
+            if sid == self._current_session_id and self._current_ai_bubble:
+                self._current_ai_bubble.update_tool_card(tool_call.id, tool_call.result)
 
     def _format_error(self, error_msg: str | None) -> str:
         hint = ""

--- a/app/ui/chat_session_controller.py
+++ b/app/ui/chat_session_controller.py
@@ -579,10 +579,10 @@ class ChatSessionController(QObject):
             self._current_ai_bubble = self._chat.add_message(self._current_ai_msg)
         try:
             if self._current_ai_bubble:
-                self._current_ai_bubble.set_content(self._current_ai_text)
+                # 流式路径走去抖渲染，合并窗口内的多个 token 只重渲染一次。
+                self._current_ai_bubble.set_content_streaming(self._current_ai_text)
         except RuntimeError:
             self._current_ai_bubble = None
-        self._chat.scroll_bottom()
 
     def _on_tool_event(self, sid: str, call_id: str, phase: str, payload: dict):
         session = self._sessions.get(sid)
@@ -670,6 +670,13 @@ class ChatSessionController(QObject):
                     and self._current_ai_bubble is None
                 ):
                     self._current_ai_bubble = self._chat.add_message(live["ai_msg"])
+            # 终态强制立即渲染：把去抖窗口里可能还没落地的最后一段文本刷出来，
+            # 否则 done 紧跟最后一个 chunk 到达时，尾部内容会停留在上一帧。
+            if sid == self._current_session_id and self._current_ai_bubble:
+                try:
+                    self._current_ai_bubble.set_content(self._current_ai_text)
+                except RuntimeError:
+                    self._current_ai_bubble = None
             session = self._sessions.get(sid)
             if session:
                 session.messages = [

--- a/app/ui/chat_widget.py
+++ b/app/ui/chat_widget.py
@@ -7,12 +7,13 @@ from app.i18n import t as _t
 from PyQt6.QtCore import Qt, QEvent, QPoint, QSize, QTimer, pyqtSignal
 from PyQt6.QtWidgets import (
     QFrame,
+    QHBoxLayout,
     QSizePolicy,
     QTextBrowser,
     QVBoxLayout,
     QWidget,
 )
-from qfluentwidgets import IndeterminateProgressBar, SmoothScrollArea
+from qfluentwidgets import IndeterminateProgressBar, SmoothScrollArea, TransparentToolButton, FluentIcon
 
 from app.models.message import Message, MessageRole
 from app.ui.anchor_rail import AnchorRail, _AnchorPanel
@@ -116,15 +117,28 @@ class MessageBubble(QFrame):
     AI 气泡支持折叠的工具摘要：
       [工具摘要]  ← 单行 "已调用 N 个工具"，可展开
       [回复文本]  ← 最终回复内容
+
+    悬停时底部浮现操作条：AI 气泡可复制/重新生成，用户气泡可编辑。
+    操作条默认只对「最后一轮」气泡启用（由 ChatWidget 控制），符合
+    「只重生/编辑最后一条」的语义，避免改动中间历史。
     """
+
+    # 携带本气泡的 Message，交由上层（控制器）决定如何处理。
+    copy_requested = pyqtSignal(object)
+    regenerate_requested = pyqtSignal(object)
+    edit_requested = pyqtSignal(object)
 
     def __init__(self, message: Message, parent=None):
         super().__init__(parent)
         self._is_user = message.role == MessageRole.USER
+        self._message = message
         self._text = message.content or ""
         self._tool_summary: ToolSummaryWidget | None = None
-        self.setObjectName("userMessage" if self._is_user else "aiMessage")
-        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        self._actions: QWidget | None = None
+        self._actions_enabled = False
+        # 外层容器透明，只作布局；带背景的气泡本体是内层 self._frame。
+        # 操作条放在气泡本体「之外、下方」，悬停显示时不会撑高气泡本身。
+        self.setObjectName("bubbleContainer")
         if self._is_user:
             self.setSizePolicy(
                 QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
@@ -136,11 +150,33 @@ class MessageBubble(QFrame):
         return self._is_user
 
     @property
+    def message(self) -> Message:
+        return self._message
+
+    @property
     def text(self) -> str:
         return self._text
 
     def _build(self, message: Message):
-        layout = QVBoxLayout(self)
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(2)
+
+        # 气泡本体：带背景/边框的内层 frame，只装内容，悬停不受操作条影响。
+        self._frame = QFrame(self)
+        self._frame.setObjectName("userMessage" if self._is_user else "aiMessage")
+        self._frame.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        if self._is_user:
+            # 用户气泡按内容自适应宽度（右对齐）。
+            self._frame.setSizePolicy(
+                QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
+            )
+        else:
+            # AI 气泡撑满内容列宽，否则回复框会被压成半宽。
+            self._frame.setSizePolicy(
+                QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+            )
+        layout = QVBoxLayout(self._frame)
         if self._is_user:
             layout.setContentsMargins(10, 2, 10, 2)
         else:
@@ -182,6 +218,90 @@ class MessageBubble(QFrame):
             self._content.hide()
         layout.addWidget(self._content)
 
+        if self._is_user:
+            # 右对齐让用户气泡贴右；AI 气泡不设对齐，撑满内容列宽。
+            outer.addWidget(self._frame, alignment=Qt.AlignmentFlag.AlignRight)
+        else:
+            outer.addWidget(self._frame)
+
+        # 操作条在气泡本体之外、下方。用固定高度容器承托，隐藏时也占位，
+        # 悬停显示不引起布局跳动（气泡不再变高）。
+        self._actions = self._build_actions()
+        self._actions_holder = QWidget(self)
+        self._actions_holder.setObjectName("bubbleActionsHolder")
+        holder_layout = QHBoxLayout(self._actions_holder)
+        holder_layout.setContentsMargins(0, 0, 0, 0)
+        holder_layout.setSpacing(0)
+        if self._is_user:
+            holder_layout.addStretch(1)
+            holder_layout.addWidget(self._actions)
+        else:
+            holder_layout.addWidget(self._actions)
+            holder_layout.addStretch(1)
+        self._actions_holder.setFixedHeight(22)
+        outer.addWidget(self._actions_holder)
+        self._actions.hide()
+
+    def _build_actions(self) -> QWidget:
+        """底部悬停操作条：AI=复制/重新生成，用户=复制/编辑。"""
+        bar = QWidget(self)
+        bar.setObjectName("bubbleActions")
+        row = QHBoxLayout(bar)
+        row.setContentsMargins(2, 0, 2, 0)
+        row.setSpacing(2)
+
+        def _btn(icon, tip, slot) -> TransparentToolButton:
+            b = TransparentToolButton(icon, bar)
+            b.setFixedSize(20, 20)
+            b.setIconSize(QSize(12, 12))
+            b.setToolTip(tip)
+            b.clicked.connect(slot)
+            row.addWidget(b)
+            return b
+
+        self._copy_btn = _btn(
+            FluentIcon.COPY, _t("chat.action.copy"), self._on_copy_clicked
+        )
+        if self._is_user:
+            _btn(FluentIcon.EDIT, _t("chat.action.edit"),
+                 lambda: self.edit_requested.emit(self._message))
+        else:
+            _btn(FluentIcon.SYNC, _t("chat.action.regenerate"),
+                 lambda: self.regenerate_requested.emit(self._message))
+        return bar
+
+    def _on_copy_clicked(self):
+        """复制后把按钮图标临时切成对号，短暂后还原——无需弹通知。"""
+        self.copy_requested.emit(self._message)
+        self._copy_btn.setIcon(FluentIcon.ACCEPT)
+        QTimer.singleShot(1500, self._restore_copy_icon)
+
+    def _restore_copy_icon(self):
+        # 气泡可能已被销毁（重新生成/切会话），忽略即可。
+        try:
+            self._copy_btn.setIcon(FluentIcon.COPY)
+        except RuntimeError:
+            pass
+
+    def set_actions_enabled(self, enabled: bool):
+        """是否允许显示操作条（仅最后一轮气泡开启）。"""
+        self._actions_enabled = enabled
+        if not enabled and self._actions is not None:
+            self._actions.hide()
+
+    def enterEvent(self, event):
+        super().enterEvent(event)
+        if self._actions_enabled and self._actions is not None:
+            # 空 AI 气泡（还没有内容）不显示操作条。
+            if not self._is_user and not self._text:
+                return
+            self._actions.show()
+
+    def leaveEvent(self, event):
+        super().leaveEvent(event)
+        if self._actions is not None:
+            self._actions.hide()
+
     # -- 内部 --------------------------------------------------------
 
     # -- 公开 API -------------------------------------------------------
@@ -207,6 +327,9 @@ class MessageBubble(QFrame):
 
     def set_content(self, text: str):
         """设置回复文本内容，根据是否有内容自动显示/隐藏。"""
+        self._text = text
+        # 保持 message.content 与气泡显示同步，供复制/重新生成读取最新文本。
+        self._message.content = text
         self._content.set_text(text)
         if not self._is_user:
             self._content.setVisible(bool(text))
@@ -216,6 +339,9 @@ class ChatWidget(QWidget):
     """可滚动的消息列表，支持拖放文件附件。"""
 
     file_attached = pyqtSignal(list)  # 发射 Attachment 列表
+    copy_message = pyqtSignal(object)       # 复制某条 AI 回复（Message）
+    regenerate_message = pyqtSignal(object)  # 重新生成某条 AI 回复（Message）
+    edit_message = pyqtSignal(object)        # 编辑某条用户消息（Message）
 
     _MAX_CONTENT_WIDTH = 760  # content column max width; centered when viewport is wider
     _PANEL_RAIL_GAP = 6       # 锚点面板与轨道之间的间隙
@@ -354,14 +480,38 @@ class ChatWidget(QWidget):
 
     def add_message(self, message: Message) -> MessageBubble:
         bubble = MessageBubble(message)
+        self._register_bubble(bubble)
         self._bubbles.append(bubble)
         if bubble.is_user:
             self._layout.addWidget(bubble, alignment=Qt.AlignmentFlag.AlignRight)
         else:
             self._layout.addWidget(bubble)
+        self._refresh_action_targets()
         QTimer.singleShot(30, self._scroll_bottom)
         QTimer.singleShot(30, self._rebuild_anchors)
         return bubble
+
+    def _register_bubble(self, bubble: MessageBubble):
+        """把气泡的操作信号转发到 ChatWidget 层。"""
+        bubble.copy_requested.connect(self.copy_message)
+        bubble.regenerate_requested.connect(self.regenerate_message)
+        bubble.edit_requested.connect(self.edit_message)
+
+    def _refresh_action_targets(self):
+        """只让最后一条用户气泡与最后一条 AI 气泡启用操作条。
+
+        「只限最后一轮」：编辑作用于最后一条用户消息，重新生成/复制作用于
+        最后一条 AI 回复；更早的气泡不显示操作条，避免改动中间历史。
+        """
+        last_user = None
+        last_ai = None
+        for b in self._bubbles:
+            if b.is_user:
+                last_user = b
+            else:
+                last_ai = b
+        for b in self._bubbles:
+            b.set_actions_enabled(b is last_user or b is last_ai)
 
     def last_bubble(self) -> MessageBubble | None:
         return self._bubbles[-1] if self._bubbles else None
@@ -371,6 +521,7 @@ class ChatWidget(QWidget):
             self._bubbles.remove(bubble)
         bubble.setParent(None)
         bubble.deleteLater()
+        self._refresh_action_targets()
         self._rebuild_anchors()
 
     def clear(self):
@@ -403,6 +554,7 @@ class ChatWidget(QWidget):
                     group.append(messages[i])
                     i += 1
                 self._add_assistant_group(group)
+        self._refresh_action_targets()
         QTimer.singleShot(80, self._scroll_bottom)
         QTimer.singleShot(80, self._rebuild_anchors)
 
@@ -429,6 +581,7 @@ class ChatWidget(QWidget):
             tool_calls=all_tool_calls,
         )
         bubble = MessageBubble(combined)
+        self._register_bubble(bubble)
         self._bubbles.append(bubble)
         self._layout.addWidget(bubble)
 

--- a/app/ui/chat_widget.py
+++ b/app/ui/chat_widget.py
@@ -169,6 +169,12 @@ class MessageBubble(QFrame):
     def message(self) -> Message:
         return self._message
 
+    def bind_message(self, message: Message) -> None:
+        """Retarget message actions while preserving the merged bubble UI."""
+        if (message.role == MessageRole.USER) != self._is_user:
+            raise ValueError("message role does not match bubble type")
+        self._message = message
+
     @property
     def text(self) -> str:
         return self._text
@@ -339,6 +345,7 @@ class MessageBubble(QFrame):
         if self._is_user:
             return
         self._cancel_pending_render()
+        self._text = ""
         self._content.set_text("")
         self._content.hide()
 
@@ -348,11 +355,9 @@ class MessageBubble(QFrame):
         每个 token 都重跑一遍「累积全文」的 markdown 解析 + 全量文本布局，
         长回复下是 O(n²) 的主线程开销，token 越多越卡。这里用去抖定时器把
         窗口内的多次更新压成一次渲染，稳定住 CPU 占用与滚动流畅度。
-        始终同步 message.content（供复制/重新生成读取最新文本），只把「重渲染」
-        这一步延后。
+        持久化 Message 由控制器唯一写入；气泡只维护展示状态并延后重渲染。
         """
         self._text = text
-        self._message.content = text
         self._pending_text = text
         if self._render_timer is None:
             self._render_timer = QTimer(self)
@@ -380,8 +385,6 @@ class MessageBubble(QFrame):
         """立即设置回复文本内容（终态：完成/出错/取消），并取消挂起的去抖渲染。"""
         self._cancel_pending_render()
         self._text = text
-        # 保持 message.content 与气泡显示同步，供复制/重新生成读取最新文本。
-        self._message.content = text
         self._content.set_text(text)
         if not self._is_user:
             self._content.setVisible(bool(text))
@@ -582,7 +585,9 @@ class ChatWidget(QWidget):
         side = max(16, (viewport_width - self._MAX_CONTENT_WIDTH) // 2)
         self._layout.setContentsMargins(side, 20, side, 20)
 
-    def add_message(self, message: Message) -> MessageBubble:
+    def add_message(
+        self, message: Message, *, defer_updates: bool = False
+    ) -> MessageBubble:
         # 新用户消息开启新一轮，恢复自动跟随到底部；AI 流式 chunk 追加气泡时
         # 不重置该状态，否则会覆盖用户在输出期间主动选择的位置。
         if message.role == MessageRole.USER:
@@ -594,9 +599,10 @@ class ChatWidget(QWidget):
             self._layout.addWidget(bubble, alignment=Qt.AlignmentFlag.AlignRight)
         else:
             self._layout.addWidget(bubble)
-        self._refresh_action_targets()
-        QTimer.singleShot(30, self._scroll_bottom)
-        QTimer.singleShot(30, self._rebuild_anchors)
+        if not defer_updates:
+            self._refresh_action_targets()
+            QTimer.singleShot(30, self._scroll_bottom)
+            QTimer.singleShot(30, self._rebuild_anchors)
         return bubble
 
     def _register_bubble(self, bubble: MessageBubble):
@@ -656,7 +662,7 @@ class ChatWidget(QWidget):
                 i += 1
                 continue
             if msg.role == MessageRole.USER:
-                self.add_message(msg)
+                self.add_message(msg, defer_updates=True)
                 i += 1
             else:  # ASSISTANT
                 group: list[Message] = []

--- a/app/ui/chat_widget.py
+++ b/app/ui/chat_widget.py
@@ -4,7 +4,15 @@ import markdown as _md
 
 from app.i18n import t as _t
 
-from PyQt6.QtCore import Qt, QEvent, QPoint, QSize, QTimer, pyqtSignal
+from PyQt6.QtCore import (
+    QAbstractAnimation,
+    Qt,
+    QEvent,
+    QPoint,
+    QSize,
+    QTimer,
+    pyqtSignal,
+)
 from PyQt6.QtWidgets import (
     QFrame,
     QHBoxLayout,
@@ -127,6 +135,11 @@ class MessageBubble(QFrame):
     copy_requested = pyqtSignal(object)
     regenerate_requested = pyqtSignal(object)
     edit_requested = pyqtSignal(object)
+    # 文本实际完成布局后发出，ChatWidget 据此在新 maximum 上执行受控回底。
+    content_rendered = pyqtSignal()
+
+    # 流式渲染去抖窗口：窗口内到达的多个 token 合并成一次 markdown 重渲染。
+    _RENDER_INTERVAL_MS = 40
 
     def __init__(self, message: Message, parent=None):
         super().__init__(parent)
@@ -136,6 +149,9 @@ class MessageBubble(QFrame):
         self._tool_summary: ToolSummaryWidget | None = None
         self._actions: QWidget | None = None
         self._actions_enabled = False
+        # 流式渲染去抖：挂起的待渲染文本与合并定时器。
+        self._pending_text: str | None = None
+        self._render_timer: QTimer | None = None
         # 外层容器透明，只作布局；带背景的气泡本体是内层 self._frame。
         # 操作条放在气泡本体「之外、下方」，悬停显示时不会撑高气泡本身。
         self.setObjectName("bubbleContainer")
@@ -322,17 +338,54 @@ class MessageBubble(QFrame):
         """清空并隐藏文本区域（工具调用开始时调用）。"""
         if self._is_user:
             return
+        self._cancel_pending_render()
         self._content.set_text("")
         self._content.hide()
 
+    def set_content_streaming(self, text: str) -> None:
+        """流式增量更新：合并 ~40ms 内到达的多个 chunk，只重渲染一次。
+
+        每个 token 都重跑一遍「累积全文」的 markdown 解析 + 全量文本布局，
+        长回复下是 O(n²) 的主线程开销，token 越多越卡。这里用去抖定时器把
+        窗口内的多次更新压成一次渲染，稳定住 CPU 占用与滚动流畅度。
+        始终同步 message.content（供复制/重新生成读取最新文本），只把「重渲染」
+        这一步延后。
+        """
+        self._text = text
+        self._message.content = text
+        self._pending_text = text
+        if self._render_timer is None:
+            self._render_timer = QTimer(self)
+            self._render_timer.setSingleShot(True)
+            self._render_timer.timeout.connect(self._flush_pending_render)
+        if not self._render_timer.isActive():
+            self._render_timer.start(self._RENDER_INTERVAL_MS)
+
+    def _flush_pending_render(self) -> None:
+        if self._pending_text is None:
+            return
+        text = self._pending_text
+        self._pending_text = None
+        self._content.set_text(text)
+        if not self._is_user:
+            self._content.setVisible(bool(text))
+        self.content_rendered.emit()
+
+    def _cancel_pending_render(self) -> None:
+        self._pending_text = None
+        if self._render_timer is not None and self._render_timer.isActive():
+            self._render_timer.stop()
+
     def set_content(self, text: str):
-        """设置回复文本内容，根据是否有内容自动显示/隐藏。"""
+        """立即设置回复文本内容（终态：完成/出错/取消），并取消挂起的去抖渲染。"""
+        self._cancel_pending_render()
         self._text = text
         # 保持 message.content 与气泡显示同步，供复制/重新生成读取最新文本。
         self._message.content = text
         self._content.set_text(text)
         if not self._is_user:
             self._content.setVisible(bool(text))
+        self.content_rendered.emit()
 
 
 class ChatWidget(QWidget):
@@ -350,6 +403,9 @@ class ChatWidget(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._bubbles: list[MessageBubble] = []
+        # 流式输出默认跟随底部；用户滚轮/拖动滚动条/点锚点后暂停，
+        # 直到用户自己回到底部或开始新的会话轮次。
+        self._auto_follow_stream = True
         self.setAcceptDrops(True)
         self._build()
 
@@ -385,6 +441,12 @@ class ChatWidget(QWidget):
         self._scroll.verticalScrollBar().valueChanged.connect(
             self._on_scroll_changed
         )
+        # SmoothScrollArea 隐藏原生滚动条，用户实际操作的是 delegate 的
+        # 自定义 vScrollBar。其 handle/箭头不会可靠发 sliderPressed，因此直接
+        # 监听滚动条及全部子控件的真实鼠标事件。
+        custom_bar = self._scroll.delegate.vScrollBar
+        for widget in (custom_bar, *custom_bar.findChildren(QWidget)):
+            widget.installEventFilter(self)
 
         # 悬停时弹出的问题列表面板（整体框 + 主题背景）
         self._anchor_panel = _AnchorPanel(self._scroll.viewport())
@@ -407,9 +469,29 @@ class ChatWidget(QWidget):
     # -- public ----------------------------------------------------------
 
     def eventFilter(self, obj, event):
-        if obj is self._scroll.viewport() and event.type() == QEvent.Type.Resize:
-            self._update_inner_margins(event.size().width())
-            self._reposition_rail()
+        event_type = event.type()
+        if obj is self._scroll.viewport():
+            if event_type == QEvent.Type.Resize:
+                self._update_inner_margins(event.size().width())
+                self._reposition_rail()
+            elif event_type == QEvent.Type.Wheel:
+                # 在底部继续向下滚不改变位置，应继续跟随；向上滚或尚未到底
+                # 时滚动，才表示用户接管位置。
+                delta = event.angleDelta().y()
+                sb = self._scroll.verticalScrollBar()
+                has_scroll_range = sb.maximum() > sb.minimum()
+                is_down_at_bottom = delta < 0 and sb.value() >= sb.maximum()
+                if has_scroll_range and delta and not is_down_at_bottom:
+                    self._pause_auto_follow()
+        else:
+            custom_bar = self._scroll.delegate.vScrollBar
+            is_scroll_control = obj is custom_bar or custom_bar.isAncestorOf(obj)
+            if is_scroll_control and event_type == QEvent.Type.MouseButtonPress:
+                self._pause_auto_follow()
+            elif is_scroll_control and event_type == QEvent.Type.MouseButtonRelease:
+                # 箭头 clicked 会在 release 处理后启动 SmoothScrollBar 动画；零延迟
+                # 回调执行时原生滚动条可能仍在底部，不能据此过早恢复自动跟随。
+                QTimer.singleShot(0, self._resume_auto_follow_after_scroll_release)
         return super().eventFilter(obj, event)
 
     def _reposition_rail(self):
@@ -429,6 +511,28 @@ class ChatWidget(QWidget):
     def _on_scroll_changed(self):
         self._anchor_rail.refresh()
         self._anchor_panel.set_active(self._anchor_rail.active_index())
+        self._resume_auto_follow_at_bottom()
+
+    def _resume_auto_follow_after_scroll_release(self) -> None:
+        """滚动控件释放且没有待完成动画时，按最终位置恢复跟随。"""
+        custom_bar = self._scroll.delegate.vScrollBar
+        animation = getattr(custom_bar, "ani", None)
+        if (
+            animation is not None
+            and animation.state() == QAbstractAnimation.State.Running
+        ):
+            return
+        self._resume_auto_follow_at_bottom()
+
+    def _resume_auto_follow_at_bottom(self) -> None:
+        """当前位置在底部时恢复流式自动跟随。"""
+        sb = self._scroll.verticalScrollBar()
+        if sb.value() >= sb.maximum():
+            self._auto_follow_stream = True
+
+    def _pause_auto_follow(self) -> None:
+        """用户主动指定滚动位置时，暂停流式自动回底。"""
+        self._auto_follow_stream = False
 
     def _show_anchor_panel(self):
         self._hide_panel_timer.stop()
@@ -479,6 +583,10 @@ class ChatWidget(QWidget):
         self._layout.setContentsMargins(side, 20, side, 20)
 
     def add_message(self, message: Message) -> MessageBubble:
+        # 新用户消息开启新一轮，恢复自动跟随到底部；AI 流式 chunk 追加气泡时
+        # 不重置该状态，否则会覆盖用户在输出期间主动选择的位置。
+        if message.role == MessageRole.USER:
+            self._auto_follow_stream = True
         bubble = MessageBubble(message)
         self._register_bubble(bubble)
         self._bubbles.append(bubble)
@@ -492,10 +600,11 @@ class ChatWidget(QWidget):
         return bubble
 
     def _register_bubble(self, bubble: MessageBubble):
-        """把气泡的操作信号转发到 ChatWidget 层。"""
+        """把气泡操作信号转发到 ChatWidget，并在文本布局后执行受控回底。"""
         bubble.copy_requested.connect(self.copy_message)
         bubble.regenerate_requested.connect(self.regenerate_message)
         bubble.edit_requested.connect(self.edit_message)
+        bubble.content_rendered.connect(self.scroll_bottom)
 
     def _refresh_action_targets(self):
         """只让最后一条用户气泡与最后一条 AI 气泡启用操作条。
@@ -538,6 +647,7 @@ class ChatWidget(QWidget):
           - 链中所有消息的工具调用 → 工具卡片
           - 最后一条有文本的消息 → 回复内容
         """
+        self._auto_follow_stream = True
         self.clear()
         i = 0
         while i < len(messages):
@@ -586,7 +696,9 @@ class ChatWidget(QWidget):
         self._layout.addWidget(bubble)
 
     def scroll_bottom(self):
-        QTimer.singleShot(30, self._scroll_bottom)
+        """流式输出请求跟随底部；用户已接管滚动时保持其指定位置。"""
+        if self._auto_follow_stream:
+            QTimer.singleShot(30, self._scroll_bottom)
 
     def _rebuild_anchors(self):
         """收集所有用户问题气泡，刷新锚点轨道。"""
@@ -598,6 +710,8 @@ class ChatWidget(QWidget):
         """平滑滚动，使指定气泡顶部对齐视口上沿。"""
         if bubble not in self._bubbles:
             return
+        # 侧边问题锚点是用户显式选择的位置，流式输出不得马上拉回底部。
+        self._pause_auto_follow()
         target = bubble.mapTo(self._inner, QPoint(0, 0)).y()
         sb = self._scroll.verticalScrollBar()
         # 留出少许上边距，避免紧贴顶部
@@ -611,10 +725,25 @@ class ChatWidget(QWidget):
             self._sync_smooth_scroll(value)
 
     def _scroll_bottom(self):
+        # 二次检查用于拦住用户操作前已经排队的 30ms 延迟回底任务。
+        if not self._auto_follow_stream:
+            return
         sb = self._scroll.verticalScrollBar()
+        self._stop_smooth_scroll_animation()
         sb.setValue(sb.maximum())
         self._sync_smooth_scroll(sb.maximum())
         self._anchor_rail.refresh()
+
+    def _stop_smooth_scroll_animation(self) -> None:
+        """停止会覆盖程序化滚动位置的未完成平滑动画。"""
+        delegate = getattr(self._scroll, "delegate", None)
+        bar = getattr(delegate, "vScrollBar", None)
+        animation = getattr(bar, "ani", None)
+        if (
+            animation is not None
+            and animation.state() == QAbstractAnimation.State.Running
+        ):
+            animation.stop()
 
     def _sync_smooth_scroll(self, value: int):
         """同步 qfluentwidgets SmoothScrollBar 的内部累加器。

--- a/app/ui/input_widget.py
+++ b/app/ui/input_widget.py
@@ -7,7 +7,12 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from qfluentwidgets import PrimaryToolButton, FluentIcon
+from qfluentwidgets import (
+    CaptionLabel,
+    FluentIcon,
+    PrimaryToolButton,
+    TransparentToolButton,
+)
 
 from app.ui.style import (
     get_text_color,
@@ -26,18 +31,41 @@ _BOTTOM_MARGIN = 30
 
 class InputWidget(QWidget):
     submitted = pyqtSignal(str)
+    edit_submitted = pyqtSignal(str)
+    edit_cancel_requested = pyqtSignal()
     cancel_requested = pyqtSignal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setObjectName("inputWidget")
         self._running = False
+        self._cancelling = False
+        self._editing = False
+        self._changing_edit = False
+        self._draft_text = ""
+        self._draft_attachments: list = []
+        self._has_draft_snapshot = False
         self._build()
 
     def _build(self):
         self._root = QVBoxLayout(self)
         self._root.setContentsMargins(_SIDE_MIN, 8, _SIDE_MIN, _BOTTOM_MARGIN)
         self._root.setSpacing(6)
+
+        self._edit_bar = QWidget(self)
+        edit_row = QHBoxLayout(self._edit_bar)
+        edit_row.setContentsMargins(4, 0, 4, 0)
+        edit_row.setSpacing(4)
+        edit_row.addWidget(CaptionLabel(t("input.editing"), self._edit_bar))
+        edit_row.addStretch()
+        self._cancel_edit_btn = TransparentToolButton(
+            FluentIcon.CLOSE, self._edit_bar
+        )
+        self._cancel_edit_btn.setToolTip(t("input.cancelEdit"))
+        self._cancel_edit_btn.clicked.connect(self.cancel_edit)
+        edit_row.addWidget(self._cancel_edit_btn)
+        self._edit_bar.hide()
+        self._root.addWidget(self._edit_bar)
 
         # 待发送附件预览条（拖放/粘贴的图片在发送前显示在这里）。
         # 用左对齐的容器包裹，使预览条只占内容宽度、不与输入框一样宽。
@@ -59,6 +87,7 @@ class InputWidget(QWidget):
         self._edit.setMaximumHeight(120)
         self._edit.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
         self._edit.submitted.connect(self._submit)
+        self._edit.textChanged.connect(self._on_text_changed)
         self._edit.files_dropped.connect(self._on_files_dropped)
         row.addWidget(self._edit)
 
@@ -77,6 +106,7 @@ class InputWidget(QWidget):
         self._root.addLayout(row)
         self._side = _SIDE_MIN
         self._pending_bar.changed.connect(self._update_margins)
+        self._pending_bar.changed.connect(self._on_pending_changed)
 
     def resizeEvent(self, event):
         super().resizeEvent(event)
@@ -97,15 +127,23 @@ class InputWidget(QWidget):
         self._root.setContentsMargins(self._side, 8, self._side, bottom)
 
     def _submit(self):
-        if self._running:
+        if self._running or self._cancelling:
             return
         text = self._edit.toPlainText().strip()
         # 允许仅附件、无文字时发送（如只拖一张图）。
         if text or self.has_pending_attachments():
-            self.submitted.emit(text)
+            is_editing = self._editing
+            self._set_editing(False)
+            if is_editing:
+                self.edit_submitted.emit(text)
+                self._discard_draft_snapshot()
+            else:
+                self.submitted.emit(text)
             self._edit.clear()
 
     def _on_button_clicked(self):
+        if self._cancelling:
+            return
         if self._running:
             self.cancel_requested.emit()
         else:
@@ -113,12 +151,89 @@ class InputWidget(QWidget):
 
     def set_running(self, running: bool):
         self._running = running
+        self._cancelling = False
         self._edit.setEnabled(True)
         self._btn.setEnabled(True)
         # 纯图标按钮：不设文本，仅切换图标（在 _apply_btn_ink 内按 _running 决定
         # SEND/CLOSE）；文字提示放 tooltip 保留可达性。
         self._btn.setToolTip(t("input.cancel") if running else t("input.send"))
         self._apply_btn_ink()
+
+    def set_cancelling(self, cancelling: bool) -> None:
+        """Keep input locked until a cancelled worker actually exits."""
+        self._cancelling = cancelling
+        self._running = cancelling or self._running
+        self._btn.setEnabled(not cancelling)
+        self._btn.setToolTip(
+            t("input.cancelling") if cancelling else t("input.cancel")
+        )
+        self._apply_btn_ink()
+
+    @property
+    def is_editing(self) -> bool:
+        return self._editing
+
+    def begin_edit(self, text: str, attachments: list) -> None:
+        """Replace the current draft and enter explicit edit mode."""
+        self._changing_edit = True
+        try:
+            if not self._editing:
+                self._draft_text = self._edit.toPlainText()
+                self._draft_attachments = self._pending_bar.take_all()
+                self._has_draft_snapshot = True
+            else:
+                self._pending_bar.clear()
+            self.add_pending_attachments(list(attachments))
+            self.set_text(text)
+            self._set_editing(True)
+        finally:
+            self._changing_edit = False
+
+    def end_edit(self, *, clear: bool) -> None:
+        self._changing_edit = True
+        try:
+            self._set_editing(False)
+            self._pending_bar.clear()
+            if clear and self._has_draft_snapshot:
+                self.set_text(self._draft_text)
+                self.add_pending_attachments(self._draft_attachments)
+            elif clear:
+                self._edit.clear()
+            self._draft_text = ""
+            self._draft_attachments = []
+            self._has_draft_snapshot = False
+        finally:
+            self._changing_edit = False
+
+    def cancel_edit(self) -> None:
+        if not self._editing:
+            return
+        self.end_edit(clear=True)
+        self.edit_cancel_requested.emit()
+
+    def _discard_draft_snapshot(self) -> None:
+        self._draft_text = ""
+        self._draft_attachments = []
+        self._has_draft_snapshot = False
+
+    def _set_editing(self, editing: bool) -> None:
+        self._editing = editing
+        self._edit_bar.setVisible(editing)
+        self._update_margins()
+
+    def _on_text_changed(self) -> None:
+        if self._changing_edit or not self._editing:
+            return
+        if not self._edit.toPlainText() and not self.has_pending_attachments():
+            self.end_edit(clear=False)
+            self.edit_cancel_requested.emit()
+
+    def _on_pending_changed(self) -> None:
+        if self._changing_edit or not self._editing:
+            return
+        if not self.has_pending_attachments() and not self._edit.toPlainText():
+            self.end_edit(clear=False)
+            self.edit_cancel_requested.emit()
 
     def _apply_btn_ink(self):
         """按主题给发送/取消按钮上色：背景用混淡后的强调色（不那么跳、

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -393,6 +393,8 @@ class MainWindow(FluentWindow):
         self._chat_col.addWidget(self._tool_status)
         self._input = InputWidget()
         self._input.submitted.connect(self._on_submit)
+        self._input.edit_submitted.connect(self._on_edit_submit)
+        self._input.edit_cancel_requested.connect(self._cancel_edit)
         self._input.cancel_requested.connect(self._cancel_worker)
         self._chat_col.addWidget(self._input)
         chat_col = self._chat_col
@@ -537,6 +539,13 @@ class MainWindow(FluentWindow):
     @pyqtSlot(str)
     def _on_submit(self, text: str):
         self._chat_session_controller.submit(text)
+
+    @pyqtSlot(str)
+    def _on_edit_submit(self, text: str):
+        self._chat_session_controller.submit_edit(text)
+
+    def _cancel_edit(self):
+        self._chat_session_controller.cancel_edit()
 
     # ──────────────────────────────────────────── 调度器回调
     def _on_scheduler_result(self, job_id: str, job_name: str, result: dict):

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -135,6 +135,13 @@ class MainWindow(FluentWindow):
             consolidator=self._consolidator,
             trace_store=self._trace_store,
         )
+        # 消息级操作（复制/重新生成/编辑）：气泡信号 → 会话控制器。
+        # 必须在控制器创建之后连接（_build_ui 阶段控制器尚不存在）。
+        self._chat.copy_message.connect(self._chat_session_controller.copy_reply)
+        self._chat.regenerate_message.connect(
+            self._chat_session_controller.regenerate_last
+        )
+        self._chat.edit_message.connect(self._chat_session_controller.edit_last)
         # 识图：每次截图动作新建一个会话，附上图片并按动作处理（自动发送或等输入）
         self._screenshot_controller.set_chat_callbacks(
             vision_callback=self._chat_session_controller.start_vision_session,

--- a/app/ui/style.py
+++ b/app/ui/style.py
@@ -1039,10 +1039,30 @@ def _build_custom_qss(theme: dict, content_font_size: int = 15, editor_font_size
 
     return f"""
 /* ═══════════════════════════════════════════════════════════════════
+   Primary Tab Canvas
+   ═══════════════════════════════════════════════════════════════════ */
+#chatInterface,
+#notesInterface,
+#toolboxInterface,
+#chatArea,
+#noteEditorPanel,
+#toolDetailPanel,
+#sessionPanel,
+#noteListPanel,
+#toolListPanel {{
+    background: {surface};
+}}
+#sessionList,
+#noteList,
+#toolList {{
+    background: transparent;
+}}
+
+/* ═══════════════════════════════════════════════════════════════════
    Chat Area
    ═══════════════════════════════════════════════════════════════════ */
 #chatArea {{
-    background: transparent;
+    border: none;
 }}
 
 /* ═══════════════════════════════════════════════════════════════════
@@ -1072,7 +1092,6 @@ SegmentedWidget > QWidget:checked {{
    Session Panel — accent left stripe on selected item
    ═══════════════════════════════════════════════════════════════════ */
 #sessionPanel {{
-    background: {surface};
     border-right: 1px solid {theme["border"]};
 }}
 #panelTitle {{
@@ -1217,7 +1236,6 @@ QSplitter::handle:hover {{ background: {accent}; }}
    Notes Panel
    ═══════════════════════════════════════════════════════════════════ */
 #noteListPanel {{
-    background: {theme["surface_solid"]};
     border-radius: 10px 0 0 10px;
     border-right: 1px solid {theme["border"]};
 }}
@@ -1234,14 +1252,8 @@ QSplitter::handle:hover {{ background: {accent}; }}
    Toolbox Panel
    ═══════════════════════════════════════════════════════════════════ */
 #toolListPanel {{
-    background: {theme["surface_solid"]};
     border-right: 1px solid {theme["border"]};
     border-radius: 10px 0 0 10px;
-}}
-
-/* Note editor panel — transparent so side margins blend with window bg */
-#noteEditorPanel {{
-    background: transparent;
 }}
 
 /* Markdown editor — transparent bg, thin hover-only scrollbar at right edge */

--- a/app/ui/toolbox_panel.py
+++ b/app/ui/toolbox_panel.py
@@ -429,6 +429,7 @@ class ToolboxPanel(QWidget):
 
         # 右侧详情
         self._right = QWidget()
+        self._right.setObjectName("toolDetailPanel")
         right_layout = QVBoxLayout(self._right)
         right_layout.setContentsMargins(0, 0, 0, 0)
         right_layout.setSpacing(0)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -127,6 +127,20 @@ class SerializeTraceTest(unittest.TestCase):
         ])
 
 
+class TransitionTableTest(unittest.TestCase):
+    """状态机转换表：EXECUTE 阶段的致命工具错误必须有明确转换。"""
+
+    def test_execute_error_transitions_to_finalize(self):
+        from app.core.turn_context import TRANSITIONS
+
+        # 缺失此转换时，_state_execute 返回 "error" 会落到 run() 的兜底分支，
+        # 用 "Invalid transition" 覆盖掉真实错误文案（见 agent_loop 兜底逻辑）。
+        self.assertEqual(
+            TRANSITIONS.get((TurnState.EXECUTE, "error")),
+            TurnState.FINALIZE,
+        )
+
+
 class _RejectAllHook(AgentHook):
     def before_execute_tools(self, ctx: BeforeToolsContext):
         return [reject(tc.id, "nope") for tc in ctx.tool_calls]

--- a/tests/test_chat_session_controller.py
+++ b/tests/test_chat_session_controller.py
@@ -2,8 +2,12 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
-from app.models.message import MessageRole
+from PyQt6.QtWidgets import QApplication
+
+from app.models.message import Message, MessageRole
 from app.ui.chat_session_controller import ChatSessionController
+
+_app = QApplication.instance() or QApplication([])
 
 
 class FakeSignal:
@@ -115,6 +119,88 @@ class ChatSessionControllerTest(unittest.TestCase):
         self.prompt_builder.build.assert_called_once()
         self.assertEqual(len(FakeWorker.instances), 1)
         self.assertTrue(FakeWorker.instances[0].started)
+
+    def test_regenerate_last_truncates_after_user_and_reruns(self):
+        # 构造一轮完整对话：user + assistant。
+        self.controller.switch_session("s1")
+        self.sessions.session.messages = [
+            Message(role=MessageRole.USER, content="q1"),
+            Message(role=MessageRole.ASSISTANT, content="a1"),
+        ]
+
+        with patch("app.ui.chat_session_controller.AgentLoop", FakeWorker):
+            self.controller.regenerate_last()
+
+        # 旧 assistant 回复被丢弃，末尾是新的空 assistant 占位。
+        roles = [m.role for m in self.sessions.session.messages]
+        self.assertEqual(roles, [MessageRole.USER, MessageRole.ASSISTANT])
+        self.assertEqual(self.sessions.session.messages[0].content, "q1")
+        self.assertEqual(self.sessions.session.messages[-1].content, "")
+        self.assertTrue(FakeWorker.instances[0].started)
+
+    def test_regenerate_noop_while_worker_running(self):
+        self.controller.switch_session("s1")
+        self.sessions.session.messages = [
+            Message(role=MessageRole.USER, content="q1"),
+            Message(role=MessageRole.ASSISTANT, content="a1"),
+        ]
+        self.controller._workers["s1"] = object()  # 模拟进行中的 worker
+
+        with patch("app.ui.chat_session_controller.AgentLoop", FakeWorker):
+            self.controller.regenerate_last()
+
+        self.assertEqual(len(FakeWorker.instances), 0)
+
+    def test_edit_last_refills_input_without_truncating(self):
+        # 点「编辑」只回填输入框、登记待生效下标，不立刻改动历史。
+        self.controller.switch_session("s1")
+        user_msg = Message(role=MessageRole.USER, content="original question")
+        assistant_msg = Message(role=MessageRole.ASSISTANT, content="a1")
+        self.sessions.session.messages = [user_msg, assistant_msg]
+
+        self.controller.edit_last(user_msg)
+
+        # 历史原样保留，输入框回填原文。
+        self.assertEqual(
+            self.sessions.session.messages, [user_msg, assistant_msg]
+        )
+        self.input.set_text.assert_called_once_with("original question")
+        self.assertEqual(self.controller._pending_edit["s1"], 0)
+
+    def test_edit_then_resubmit_truncates_old_turn(self):
+        # 编辑后真正重发：旧轮（原 user + assistant）被截断，替换为新消息。
+        self.controller.switch_session("s1")
+        user_msg = Message(role=MessageRole.USER, content="original question")
+        self.sessions.session.messages = [
+            user_msg,
+            Message(role=MessageRole.ASSISTANT, content="a1"),
+        ]
+        self.input.take_pending_attachments.return_value = []
+
+        self.controller.edit_last(user_msg)
+        with patch("app.ui.chat_session_controller.AgentLoop", FakeWorker):
+            self.controller.submit("edited question")
+
+        roles = [m.role for m in self.sessions.session.messages]
+        self.assertEqual(roles, [MessageRole.USER, MessageRole.ASSISTANT])
+        self.assertEqual(self.sessions.session.messages[0].content, "edited question")
+        self.assertNotIn("s1", self.controller._pending_edit)
+
+    def test_switch_session_discards_pending_edit(self):
+        self.controller.switch_session("s1")
+        self.controller._pending_edit["s1"] = 0
+        self.controller.switch_session("s1")  # 切回同一会话保留
+        self.assertIn("s1", self.controller._pending_edit)
+        self.controller.switch_session("s2")  # 切到别的会话丢弃
+        self.assertNotIn("s1", self.controller._pending_edit)
+
+    def test_copy_reply_puts_text_on_clipboard(self):
+        from PyQt6.QtWidgets import QApplication
+
+        msg = Message(role=MessageRole.ASSISTANT, content="hello reply")
+        self.controller.copy_reply(msg)
+
+        self.assertEqual(QApplication.clipboard().text(), "hello reply")
 
     def test_cancel_keeps_partial_response_and_stops_worker(self):
         bubble = Mock()

--- a/tests/test_chat_session_controller.py
+++ b/tests/test_chat_session_controller.py
@@ -11,8 +11,44 @@ _app = QApplication.instance() or QApplication([])
 
 
 class FakeSignal:
+    def __init__(self):
+        self.callbacks = []
+
     def connect(self, callback):
-        self.callback = callback
+        self.callbacks.append(callback)
+
+    def emit(self, *args):
+        for callback in list(self.callbacks):
+            callback(*args)
+
+
+class BindingBubble:
+    """Fake the old UI behavior that writes rendered text to its bound message."""
+
+    def __init__(self, message):
+        self.message = message
+        self.text = message.content
+        self.tool_calls = []
+
+    def bind_message(self, message):
+        self.message = message
+
+    def clear_text(self):
+        self.text = ""
+
+    def set_content_streaming(self, text):
+        self.text = text
+        self.message.content = text
+
+    def set_content(self, text):
+        self.text = text
+        self.message.content = text
+
+    def add_tool_card(self, call_id, name, params):
+        self.tool_calls.append((call_id, name, params))
+
+    def update_tool_card(self, call_id, result):
+        pass
 
 
 class FakeWorker:
@@ -152,7 +188,7 @@ class ChatSessionControllerTest(unittest.TestCase):
         self.assertEqual(len(FakeWorker.instances), 0)
 
     def test_edit_last_refills_input_without_truncating(self):
-        # 点「编辑」只回填输入框、登记待生效下标，不立刻改动历史。
+        # 点「编辑」只回填输入框并进入编辑模式，不立刻改动历史。
         self.controller.switch_session("s1")
         user_msg = Message(role=MessageRole.USER, content="original question")
         assistant_msg = Message(role=MessageRole.ASSISTANT, content="a1")
@@ -160,12 +196,32 @@ class ChatSessionControllerTest(unittest.TestCase):
 
         self.controller.edit_last(user_msg)
 
-        # 历史原样保留，输入框回填原文。
+        # 历史原样保留，输入框回填原文并记录目标消息身份。
         self.assertEqual(
             self.sessions.session.messages, [user_msg, assistant_msg]
         )
-        self.input.set_text.assert_called_once_with("original question")
-        self.assertEqual(self.controller._pending_edit["s1"], 0)
+        self.input.begin_edit.assert_called_once_with(
+            "original question", []
+        )
+        self.assertEqual(self.controller._pending_edit["s1"], user_msg.id)
+
+    def test_normal_submit_does_not_consume_pending_edit(self):
+        self.controller.switch_session("s1")
+        user_msg = Message(role=MessageRole.USER, content="original question")
+        assistant_msg = Message(role=MessageRole.ASSISTANT, content="a1")
+        self.sessions.session.messages = [user_msg, assistant_msg]
+        self.input.take_pending_attachments.return_value = []
+        self.controller.edit_last(user_msg)
+
+        with patch("app.ui.chat_session_controller.AgentLoop", FakeWorker):
+            self.controller.submit("new question")
+
+        self.assertEqual(
+            [m.content for m in self.sessions.session.messages],
+            ["original question", "a1", "new question", ""],
+        )
+        self.input.end_edit.assert_called_once_with(clear=False)
+        self.assertNotIn("s1", self.controller._pending_edit)
 
     def test_edit_then_resubmit_truncates_old_turn(self):
         # 编辑后真正重发：旧轮（原 user + assistant）被截断，替换为新消息。
@@ -179,20 +235,57 @@ class ChatSessionControllerTest(unittest.TestCase):
 
         self.controller.edit_last(user_msg)
         with patch("app.ui.chat_session_controller.AgentLoop", FakeWorker):
-            self.controller.submit("edited question")
+            self.controller.submit_edit("edited question")
 
         roles = [m.role for m in self.sessions.session.messages]
         self.assertEqual(roles, [MessageRole.USER, MessageRole.ASSISTANT])
         self.assertEqual(self.sessions.session.messages[0].content, "edited question")
         self.assertNotIn("s1", self.controller._pending_edit)
 
+    def test_cancel_edit_preserves_history_and_next_submit_appends(self):
+        self.controller.switch_session("s1")
+        original = [
+            Message(role=MessageRole.USER, content="q1"),
+            Message(role=MessageRole.ASSISTANT, content="a1"),
+        ]
+        self.sessions.session.messages = original.copy()
+        self.input.take_pending_attachments.return_value = []
+        self.controller.edit_last(original[0])
+
+        self.controller.cancel_edit()
+        with patch("app.ui.chat_session_controller.AgentLoop", FakeWorker):
+            self.controller.submit("q2")
+
+        self.assertEqual(
+            [m.content for m in self.sessions.session.messages],
+            ["q1", "a1", "q2", ""],
+        )
+        self.input.end_edit.assert_not_called()
+
     def test_switch_session_discards_pending_edit(self):
         self.controller.switch_session("s1")
-        self.controller._pending_edit["s1"] = 0
+        self.controller._pending_edit["s1"] = "message-id"
         self.controller.switch_session("s1")  # 切回同一会话保留
         self.assertIn("s1", self.controller._pending_edit)
         self.controller.switch_session("s2")  # 切到别的会话丢弃
         self.assertNotIn("s1", self.controller._pending_edit)
+
+    def test_switching_back_to_cancelling_session_stops_typing_when_finished(self):
+        self.controller.switch_session("s1")
+        self.input.take_pending_attachments.return_value = []
+        with patch("app.ui.chat_session_controller.AgentLoop", FakeWorker):
+            self.controller.submit("hello")
+        worker = FakeWorker.instances[0]
+        self.controller.cancel_worker("s1")
+        self.controller.switch_session("other")
+        self.controller.switch_session("s1")
+        starts_before_finished = self.chat.start_typing.call_count
+
+        worker.finished.emit()
+
+        self.assertEqual(self.chat.start_typing.call_count, starts_before_finished)
+        self.chat.stop_typing.assert_called()
+        self.tool_status.hide.assert_called()
 
     def test_copy_reply_puts_text_on_clipboard(self):
         from PyQt6.QtWidgets import QApplication
@@ -218,9 +311,145 @@ class ChatSessionControllerTest(unittest.TestCase):
         marker = t("chat.cancelled")
         self.assertEqual(self.sessions.session.messages[-1].content, f"partial\n\n{marker}")
         bubble.set_content.assert_any_call(f"partial\n\n{marker}")
-        self.input.set_running.assert_called_with(False)
+        self.input.set_cancelling.assert_called_with(True)
         self.chat.stop_typing.assert_called()
         self.assertEqual(self.sessions.saved, ["s1"])
+
+    def test_cancelled_worker_blocks_retry_until_finished(self):
+        self.controller.switch_session("s1")
+        self.input.take_pending_attachments.return_value = []
+        with patch("app.ui.chat_session_controller.AgentLoop", FakeWorker):
+            self.controller.submit("hello")
+            worker = FakeWorker.instances[0]
+            self.controller.cancel_worker("s1")
+            self.controller.submit("retry too early")
+
+            self.assertEqual(len(FakeWorker.instances), 1)
+            self.assertIs(self.controller._workers["s1"], worker)
+
+            worker.finished.emit()
+            self.controller.submit("retry now")
+
+        self.assertEqual(len(FakeWorker.instances), 2)
+        self.assertTrue(FakeWorker.instances[1].started)
+
+    def test_cancelled_worker_ignores_late_text_and_finalizes_running_tools(self):
+        bubble = Mock()
+        self.chat.add_message.side_effect = [Mock(), bubble]
+        self.controller.switch_session("s1")
+        self.input.take_pending_attachments.return_value = []
+        with patch("app.ui.chat_session_controller.AgentLoop", FakeWorker):
+            self.controller.submit("hello")
+        worker = FakeWorker.instances[0]
+        worker.tool_event.emit(
+            "call-1", "start", {"name": "search", "params": {}}
+        )
+
+        self.controller.cancel_worker("s1")
+        cancelled_content = self.sessions.session.messages[-1].content
+        worker.text_chunk.emit("late text")
+        worker.new_turn.emit(2)
+        worker.finished.emit()
+
+        assistant = self.sessions.session.messages[-1]
+        self.assertEqual(assistant.content, cancelled_content)
+        self.assertEqual(len([
+            m for m in self.sessions.session.messages
+            if m.role == MessageRole.ASSISTANT
+        ]), 1)
+        self.assertEqual(assistant.tool_calls[0].status, "error")
+        self.assertEqual(assistant.tool_calls[0].result["status"], "error")
+        bubble.update_tool_card.assert_called_with(
+            "call-1", assistant.tool_calls[0].result
+        )
+
+    def test_cancelled_worker_persists_late_tool_success(self):
+        bubble = Mock()
+        self.chat.add_message.side_effect = [Mock(), bubble]
+        self.controller.switch_session("s1")
+        self.input.take_pending_attachments.return_value = []
+        with patch("app.ui.chat_session_controller.AgentLoop", FakeWorker):
+            self.controller.submit("hello")
+        worker = FakeWorker.instances[0]
+        worker.tool_event.emit(
+            "call-1", "start", {"name": "save_file", "params": {}}
+        )
+
+        self.controller.cancel_worker("s1")
+        worker.tool_event.emit(
+            "call-1", "done", {"result": {"status": "success"}}
+        )
+        worker.finished.emit()
+
+        tool_call = self.sessions.session.messages[-1].tool_calls[0]
+        self.assertEqual(tool_call.status, "success")
+        self.assertEqual(tool_call.result["status"], "success")
+        self.assertGreaterEqual(self.sessions.saved.count("s1"), 2)
+
+    def test_cancelled_worker_persists_queued_start_and_done(self):
+        bubble = Mock()
+        self.chat.add_message.side_effect = [Mock(), bubble]
+        self.controller.switch_session("s1")
+        self.input.take_pending_attachments.return_value = []
+        with patch("app.ui.chat_session_controller.AgentLoop", FakeWorker):
+            self.controller.submit("hello")
+        worker = FakeWorker.instances[0]
+
+        self.controller.cancel_worker("s1")
+        worker.tool_event.emit(
+            "call-1", "start", {"name": "save_file", "params": {}}
+        )
+        worker.tool_event.emit(
+            "call-1", "done", {"result": {"status": "success"}}
+        )
+        worker.finished.emit()
+
+        tool_calls = self.sessions.session.messages[-1].tool_calls
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0].name, "save_file")
+        self.assertEqual(tool_calls[0].status, "success")
+        bubble.add_tool_card.assert_not_called()
+
+    def test_tool_multiturn_does_not_overwrite_previous_messages(self):
+        bubbles = []
+
+        def add_message(message):
+            bubble = BindingBubble(message)
+            bubbles.append(bubble)
+            return bubble
+
+        self.chat.add_message.side_effect = add_message
+        self.controller.switch_session("s1")
+        self.input.take_pending_attachments.return_value = []
+        with patch("app.ui.chat_session_controller.AgentLoop", FakeWorker):
+            self.controller.submit("question")
+
+        self.controller._on_tool_event(
+            "s1", "call-1", "start", {"name": "search", "params": {}}
+        )
+        self.controller._on_tool_event(
+            "s1", "call-1", "done", {"result": {"status": "success"}}
+        )
+        self.controller._on_new_turn("s1", 1)
+        self.controller._on_tool_event(
+            "s1", "call-2", "start", {"name": "read", "params": {}}
+        )
+        self.controller._on_tool_event(
+            "s1", "call-2", "done", {"result": {"status": "success"}}
+        )
+        self.controller._on_new_turn("s1", 2)
+        self.controller._on_text_chunk("s1", "final answer")
+        self.controller._on_done("s1", {"ok": True})
+
+        assistant = [
+            message
+            for message in self.sessions.session.messages
+            if message.role == MessageRole.ASSISTANT
+        ]
+        self.assertEqual([m.content for m in assistant], ["", "", "final answer"])
+        self.assertEqual([[tc.id for tc in m.tool_calls] for m in assistant], [
+            ["call-1"], ["call-2"], []
+        ])
 
 
 if __name__ == "__main__":

--- a/tests/test_chat_session_controller.py
+++ b/tests/test_chat_session_controller.py
@@ -60,6 +60,10 @@ class FakeSessionManager:
     def save_session(self, sid):
         self.saved.append(sid)
 
+    def create(self, title="", source=""):
+        self.created = SimpleNamespace(id="reading1", title=title, source=source)
+        return self.created
+
 
 class ChatSessionControllerTest(unittest.TestCase):
     def setUp(self):
@@ -83,6 +87,18 @@ class ChatSessionControllerTest(unittest.TestCase):
             session_panel=self.session_panel,
             tool_status=self.tool_status,
         )
+
+    def test_resolve_reading_session_force_new_creates_session(self):
+        # 回归：_resolve_reading_session 曾引用未定义的 READING_SESSION_TITLE，
+        # force_new=True 时必崩 NameError。此路径是划词「新建会话」的必经之处。
+        from app.ui.chat_session_controller import reading_session_title
+
+        with patch("app.ui.chat_session_controller.cfg") as fake_cfg:
+            fake_cfg.get.return_value = ""
+            sid = self.controller._resolve_reading_session(force_new=True)
+
+        self.assertEqual(sid, "reading1")
+        self.assertEqual(self.sessions.created.title, reading_session_title())
 
     def test_submit_creates_messages_and_starts_worker(self):
         self.controller.switch_session("s1")

--- a/tests/test_fetch_url_ssrf.py
+++ b/tests/test_fetch_url_ssrf.py
@@ -24,6 +24,15 @@ class CheckUrlSafetyTest(unittest.TestCase):
         safe, _ = _check_url_safety("http://8.8.8.8")
         self.assertTrue(safe)
 
+    def test_blocks_ipv4_mapped_ipv6_loopback(self):
+        # 域名解析到 IPv4-mapped IPv6（::ffff:127.0.0.1）应被归一化后拦截，
+        # 否则原生网段比对不命中，形成 SSRF 绕过。
+        fake_infos = [(None, None, None, None, ("::ffff:127.0.0.1", 0))]
+        with mock.patch.object(fetch_url.socket, "getaddrinfo", return_value=fake_infos):
+            safe, reason = _check_url_safety("http://evil.example.com")
+        self.assertFalse(safe)
+        self.assertTrue(reason)
+
 
 class _FakeResp:
     """模拟 httpx.Response 的最小子集。"""

--- a/tests/test_input_widget.py
+++ b/tests/test_input_widget.py
@@ -1,0 +1,90 @@
+import unittest
+
+from PyQt6.QtWidgets import QApplication
+
+from app.models.attachment import Attachment
+from app.ui.input_widget import InputWidget
+
+_app = QApplication.instance() or QApplication([])
+
+
+class InputWidgetEditModeTest(unittest.TestCase):
+    def setUp(self):
+        self.widget = InputWidget()
+
+    def tearDown(self):
+        self.widget.deleteLater()
+
+    def test_begin_edit_routes_submit_to_edit_signal(self):
+        normal = []
+        edited = []
+        self.widget.submitted.connect(normal.append)
+        self.widget.edit_submitted.connect(edited.append)
+
+        self.widget.begin_edit("original", [])
+        self.widget.set_text("changed")
+        self.widget._submit()
+
+        self.assertEqual(normal, [])
+        self.assertEqual(edited, ["changed"])
+        self.assertFalse(self.widget.is_editing)
+
+    def test_explicit_cancel_clears_edit_text_and_emits_request(self):
+        requested = []
+        self.widget.edit_cancel_requested.connect(lambda: requested.append(True))
+        self.widget.begin_edit("original", [])
+
+        self.widget.cancel_edit()
+
+        self.assertEqual(requested, [True])
+        self.assertEqual(self.widget._edit.toPlainText(), "")
+        self.assertFalse(self.widget.is_editing)
+
+    def test_explicit_cancel_restores_previous_draft_and_attachments(self):
+        attachment = Attachment(
+            file_path="draft.txt",
+            file_name="draft.txt",
+            file_type="text",
+            file_size=5,
+        )
+        self.widget.set_text("draft")
+        self.widget.add_pending_attachments([attachment])
+        self.widget.begin_edit("original", [])
+
+        self.widget.cancel_edit()
+
+        self.assertEqual(self.widget._edit.toPlainText(), "draft")
+        self.assertEqual(
+            self.widget.take_pending_attachments(), [attachment]
+        )
+        self.assertFalse(self.widget.is_editing)
+
+    def test_clearing_edit_draft_exits_edit_mode(self):
+        requested = []
+        self.widget.edit_cancel_requested.connect(lambda: requested.append(True))
+        self.widget.begin_edit("original", [])
+
+        self.widget._edit.clear()
+
+        self.assertEqual(requested, [True])
+        self.assertFalse(self.widget.is_editing)
+
+    def test_cancelling_state_blocks_submit_and_second_cancel(self):
+        submitted = []
+        cancelled = []
+        self.widget.submitted.connect(submitted.append)
+        self.widget.cancel_requested.connect(lambda: cancelled.append(True))
+        self.widget.set_text("draft")
+        self.widget.set_running(True)
+        self.widget.set_cancelling(True)
+
+        self.widget._submit()
+        self.widget._on_button_clicked()
+
+        self.assertEqual(submitted, [])
+        self.assertEqual(cancelled, [])
+        self.assertFalse(self.widget._btn.isEnabled())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_message_bubble_render.py
+++ b/tests/test_message_bubble_render.py
@@ -1,0 +1,260 @@
+import unittest
+from unittest.mock import patch
+
+from PyQt6.QtCore import QAbstractAnimation, QEvent, QPoint, QPointF, Qt
+from PyQt6.QtGui import QWheelEvent
+from PyQt6.QtTest import QTest
+from PyQt6.QtWidgets import QApplication
+
+from app.models.message import Message, MessageRole
+from app.ui.chat_widget import ChatWidget, MessageBubble
+
+_app = QApplication.instance() or QApplication([])
+
+
+class MessageBubbleStreamingRenderTest(unittest.TestCase):
+    """流式去抖渲染：窗口内多次 chunk 只重渲染一次，终态立即落地。"""
+
+    def _ai_bubble(self) -> MessageBubble:
+        return MessageBubble(Message(role=MessageRole.ASSISTANT, content=""))
+
+    def test_streaming_defers_render_and_coalesces(self):
+        bubble = self._ai_bubble()
+        with patch.object(bubble._content, "set_text") as set_text:
+            # 连续多个 chunk 到达，均在去抖窗口内。
+            bubble.set_content_streaming("a")
+            bubble.set_content_streaming("ab")
+            bubble.set_content_streaming("abc")
+            # 尚未 flush：一次真正的重渲染都没发生。
+            set_text.assert_not_called()
+            self.assertEqual(bubble._pending_text, "abc")
+            # message.content 始终同步最新文本（复制/重新生成读取用）。
+            self.assertEqual(bubble.message.content, "abc")
+
+            # 定时器触发后，只渲染最后一次的合并文本。
+            bubble._flush_pending_render()
+            set_text.assert_called_once_with("abc")
+            self.assertIsNone(bubble._pending_text)
+
+    def test_streaming_flush_requests_scroll_after_layout(self):
+        bubble = self._ai_bubble()
+        scroll_requests = []
+        bubble.content_rendered.connect(lambda: scroll_requests.append(True))
+        bubble.set_content_streaming("new content")
+
+        bubble._flush_pending_render()
+
+        self.assertEqual(scroll_requests, [True])
+
+    def test_set_content_forces_immediate_render_and_cancels_pending(self):
+        bubble = self._ai_bubble()
+        bubble.set_content_streaming("partial")
+        self.assertTrue(bubble._render_timer.isActive())
+
+        with patch.object(bubble._content, "set_text") as set_text:
+            bubble.set_content("final text")
+            # 终态立即渲染。
+            set_text.assert_called_once_with("final text")
+        # 挂起的去抖被取消，不会再补一帧旧内容。
+        self.assertIsNone(bubble._pending_text)
+        self.assertFalse(bubble._render_timer.isActive())
+
+    def test_clear_text_cancels_pending_render(self):
+        bubble = self._ai_bubble()
+        bubble.set_content_streaming("half-streamed")
+        self.assertTrue(bubble._render_timer.isActive())
+
+        bubble.clear_text()
+        self.assertIsNone(bubble._pending_text)
+        self.assertFalse(bubble._render_timer.isActive())
+
+
+class ChatWidgetAutoFollowTest(unittest.TestCase):
+    """用户主动指定滚动位置后，流式自动跟随应让出控制权。"""
+
+    def test_custom_scrollbar_handle_press_pauses_auto_follow(self):
+        chat = ChatWidget()
+        custom_bar = chat._scroll.delegate.vScrollBar
+        custom_bar.setRange(0, 100)
+        custom_bar.resize(12, 200)
+        custom_bar.show()
+        custom_bar.handle.show()
+
+        QTest.mousePress(
+            custom_bar.handle,
+            Qt.MouseButton.LeftButton,
+            pos=custom_bar.handle.rect().center(),
+        )
+
+        self.assertFalse(chat._auto_follow_stream)
+        QTest.mouseRelease(
+            custom_bar.handle,
+            Qt.MouseButton.LeftButton,
+            pos=custom_bar.handle.rect().center(),
+        )
+
+    def test_custom_scrollbar_arrow_click_pauses_auto_follow(self):
+        chat = ChatWidget()
+        custom_bar = chat._scroll.delegate.vScrollBar
+        native_bar = chat._scroll.verticalScrollBar()
+        native_bar.setRange(0, 100)
+        native_bar.setValue(50)
+        custom_bar.setValue(50, useAni=False)
+
+        QTest.mouseClick(
+            custom_bar.groove.upButton,
+            Qt.MouseButton.LeftButton,
+            pos=custom_bar.groove.upButton.rect().center(),
+        )
+        QApplication.processEvents()
+
+        self.assertFalse(chat._auto_follow_stream)
+
+    def test_scrollbar_release_before_up_animation_keeps_auto_follow_paused(self):
+        chat = ChatWidget()
+        custom_bar = chat._scroll.delegate.vScrollBar
+        native_bar = chat._scroll.verticalScrollBar()
+        native_bar.setRange(0, 100)
+        native_bar.setValue(100)
+        chat._auto_follow_stream = False
+        scheduled = []
+
+        # release 事件处理完成后，箭头 clicked 会先启动动画；零延迟回调执行时，
+        # 原生滚动条仍可能停在底部，动画首帧尚未向上移动。
+        release = QEvent(QEvent.Type.MouseButtonRelease)
+        with patch(
+            "app.ui.chat_widget.QTimer.singleShot",
+            side_effect=lambda _delay, callback: scheduled.append(callback),
+        ):
+            chat.eventFilter(custom_bar.groove.upButton, release)
+        custom_bar.setValue(50)
+        self.assertEqual(native_bar.value(), 100)
+
+        scheduled[0]()
+        custom_bar.ani.stop()
+
+        self.assertFalse(chat._auto_follow_stream)
+
+    def test_anchor_jump_pauses_auto_follow(self):
+        chat = ChatWidget()
+        bubble = chat.add_message(
+            Message(role=MessageRole.USER, content="earlier question")
+        )
+
+        chat._scroll_to_bubble(bubble)
+
+        self.assertFalse(chat._auto_follow_stream)
+
+    def test_rendered_bubble_requests_controlled_scroll(self):
+        chat = ChatWidget()
+        with patch.object(chat, "scroll_bottom") as scroll_bottom:
+            bubble = chat.add_message(
+                Message(role=MessageRole.ASSISTANT, content="answer")
+            )
+            bubble.content_rendered.emit()
+
+        scroll_bottom.assert_called_once_with()
+
+    def test_wheel_event_pauses_auto_follow(self):
+        chat = ChatWidget()
+        bar = chat._scroll.verticalScrollBar()
+        bar.setRange(0, 100)
+        bar.setValue(50)
+        event = QWheelEvent(
+            QPointF(5, 5),
+            QPointF(5, 5),
+            QPoint(0, 0),
+            QPoint(0, 120),
+            Qt.MouseButton.NoButton,
+            Qt.KeyboardModifier.NoModifier,
+            Qt.ScrollPhase.ScrollUpdate,
+            False,
+        )
+
+        chat.eventFilter(chat._scroll.viewport(), event)
+
+        self.assertFalse(chat._auto_follow_stream)
+
+    def test_wheel_without_scroll_range_keeps_auto_follow(self):
+        chat = ChatWidget()
+        event = QWheelEvent(
+            QPointF(5, 5),
+            QPointF(5, 5),
+            QPoint(0, 0),
+            QPoint(0, 120),
+            Qt.MouseButton.NoButton,
+            Qt.KeyboardModifier.NoModifier,
+            Qt.ScrollPhase.ScrollUpdate,
+            False,
+        )
+
+        chat.eventFilter(chat._scroll.viewport(), event)
+
+        self.assertTrue(chat._auto_follow_stream)
+
+    def test_wheel_down_at_bottom_keeps_auto_follow(self):
+        chat = ChatWidget()
+        bar = chat._scroll.verticalScrollBar()
+        bar.setRange(0, 100)
+        bar.setValue(100)
+        event = QWheelEvent(
+            QPointF(5, 5),
+            QPointF(5, 5),
+            QPoint(0, 0),
+            QPoint(0, -120),
+            Qt.MouseButton.NoButton,
+            Qt.KeyboardModifier.NoModifier,
+            Qt.ScrollPhase.ScrollUpdate,
+            False,
+        )
+
+        chat.eventFilter(chat._scroll.viewport(), event)
+
+        self.assertTrue(chat._auto_follow_stream)
+
+    def test_returning_to_bottom_restores_auto_follow(self):
+        chat = ChatWidget()
+        chat._auto_follow_stream = False
+        bar = chat._scroll.verticalScrollBar()
+        bar.setRange(0, 100)
+        bar.setValue(100)
+
+        chat._on_scroll_changed()
+
+        self.assertTrue(chat._auto_follow_stream)
+
+    def test_pending_auto_scroll_does_not_override_user_position(self):
+        chat = ChatWidget()
+        bar = chat._scroll.verticalScrollBar()
+        bar.setRange(0, 100)
+        bar.setValue(20)
+        chat._auto_follow_stream = False
+
+        # 模拟用户操作前已经由上一 chunk 排队的延迟回底任务。
+        chat._scroll_bottom()
+
+        self.assertEqual(bar.value(), 20)
+
+    def test_scroll_bottom_stops_conflicting_smooth_animation(self):
+        chat = ChatWidget()
+        native_bar = chat._scroll.verticalScrollBar()
+        custom_bar = chat._scroll.delegate.vScrollBar
+        native_bar.setRange(0, 100)
+        custom_bar.setRange(0, 100)
+        custom_bar.setValue(100, useAni=False)
+        custom_bar.setValue(0)
+        self.assertEqual(
+            custom_bar.ani.state(), QAbstractAnimation.State.Running
+        )
+
+        chat._scroll_bottom()
+        QTest.qWait(custom_bar.ani.duration() + 50)
+
+        self.assertEqual(
+            custom_bar.ani.state(), QAbstractAnimation.State.Stopped
+        )
+        self.assertEqual(native_bar.value(), native_bar.maximum())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_message_bubble_render.py
+++ b/tests/test_message_bubble_render.py
@@ -28,8 +28,8 @@ class MessageBubbleStreamingRenderTest(unittest.TestCase):
             # 尚未 flush：一次真正的重渲染都没发生。
             set_text.assert_not_called()
             self.assertEqual(bubble._pending_text, "abc")
-            # message.content 始终同步最新文本（复制/重新生成读取用）。
-            self.assertEqual(bubble.message.content, "abc")
+            # 渲染层只维护展示状态；持久化 Message 由控制器唯一写入。
+            self.assertEqual(bubble.message.content, "")
 
             # 定时器触发后，只渲染最后一次的合并文本。
             bubble._flush_pending_render()
@@ -58,6 +58,15 @@ class MessageBubbleStreamingRenderTest(unittest.TestCase):
         # 挂起的去抖被取消，不会再补一帧旧内容。
         self.assertIsNone(bubble._pending_text)
         self.assertFalse(bubble._render_timer.isActive())
+        self.assertEqual(bubble.message.content, "")
+
+    def test_bind_message_changes_action_target(self):
+        bubble = self._ai_bubble()
+        current = Message(role=MessageRole.ASSISTANT, content="final")
+
+        bubble.bind_message(current)
+
+        self.assertIs(bubble.message, current)
 
     def test_clear_text_cancels_pending_render(self):
         bubble = self._ai_bubble()
@@ -67,6 +76,74 @@ class MessageBubbleStreamingRenderTest(unittest.TestCase):
         bubble.clear_text()
         self.assertIsNone(bubble._pending_text)
         self.assertFalse(bubble._render_timer.isActive())
+
+
+class ChatWidgetSessionLoadBatchingTest(unittest.TestCase):
+    """会话批量加载只在全部气泡就绪后统一完成派生 UI 工作。"""
+
+    @staticmethod
+    def _conversation() -> list[Message]:
+        return [
+            Message(role=MessageRole.USER, content="question 1"),
+            Message(role=MessageRole.ASSISTANT, content="answer 1"),
+            Message(role=MessageRole.USER, content="question 2"),
+            Message(role=MessageRole.ASSISTANT, content="answer 2"),
+        ]
+
+    def test_load_session_refreshes_action_targets_once(self):
+        chat = ChatWidget()
+        self.addCleanup(chat.deleteLater)
+
+        with patch.object(
+            chat,
+            "_refresh_action_targets",
+            wraps=chat._refresh_action_targets,
+        ) as refresh_action_targets:
+            chat.load_session(self._conversation())
+
+        refresh_action_targets.assert_called_once_with()
+
+    def test_load_session_queues_only_final_scroll_and_anchor_rebuild(self):
+        chat = ChatWidget()
+        self.addCleanup(chat.deleteLater)
+        scheduled = []
+
+        with patch(
+            "app.ui.chat_widget.QTimer.singleShot",
+            side_effect=lambda _delay, callback: scheduled.append(callback),
+        ):
+            chat.load_session(self._conversation())
+
+        self.assertEqual(
+            scheduled,
+            [chat._scroll_bottom, chat._rebuild_anchors],
+        )
+
+    def test_add_message_keeps_realtime_refresh_and_scheduling(self):
+        chat = ChatWidget()
+        self.addCleanup(chat.deleteLater)
+        scheduled = []
+        message = Message(role=MessageRole.USER, content="live question")
+
+        with (
+            patch.object(
+                chat,
+                "_refresh_action_targets",
+                wraps=chat._refresh_action_targets,
+            ) as refresh_action_targets,
+            patch(
+                "app.ui.chat_widget.QTimer.singleShot",
+                side_effect=lambda _delay, callback: scheduled.append(callback),
+            ),
+        ):
+            bubble = chat.add_message(message)
+
+        self.assertIs(chat.last_bubble(), bubble)
+        refresh_action_targets.assert_called_once_with()
+        self.assertEqual(
+            scheduled,
+            [chat._scroll_bottom, chat._rebuild_anchors],
+        )
 
 
 class ChatWidgetAutoFollowTest(unittest.TestCase):

--- a/tests/test_read_file_boundary.py
+++ b/tests/test_read_file_boundary.py
@@ -1,0 +1,51 @@
+"""read_file 工具的 workspace 边界测试。
+
+与 list_dir/grep/find_files 一致，read_file 必须把路径钳制在 workspace 内，
+不允许 AI 通过绝对路径或 ../ 逃逸读取任意系统文件（.ssh、凭据等）。
+"""
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from app.tools.read_file import ReadFileTool
+
+
+class ReadFileBoundaryTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.workspace = Path(self._tmp.name)
+        self.tool = ReadFileTool(workspace=self.workspace)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_reads_file_inside_workspace(self):
+        target = self.workspace / "note.txt"
+        target.write_text("hello workspace", encoding="utf-8")
+        result = self.tool.execute({"file_path": "note.txt"})
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["data"]["content"], "hello workspace")
+
+    def test_blocks_parent_traversal(self):
+        # 在 workspace 外创建一个文件，尝试用 ../ 逃逸读取应被拒绝。
+        outside = self.workspace.parent / "secret.txt"
+        outside.write_text("top secret", encoding="utf-8")
+        try:
+            result = self.tool.execute({"file_path": "../secret.txt"})
+        finally:
+            outside.unlink(missing_ok=True)
+        self.assertEqual(result["status"], "error")
+
+    def test_blocks_absolute_path_outside_workspace(self):
+        # 绝对路径指向 workspace 之外应被拒绝，不泄露内容。
+        result = self.tool.execute({"file_path": "C:/Windows/system.ini"})
+        self.assertEqual(result["status"], "error")
+
+    def test_empty_path_is_rejected(self):
+        result = self.tool.execute({"file_path": "   "})
+        self.assertEqual(result["status"], "error")
+        self.assertIn("required", result["data"]["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_theme_surface_consistency.py
+++ b/tests/test_theme_surface_consistency.py
@@ -1,0 +1,68 @@
+import re
+
+import pytest
+from PyQt6.QtWidgets import QApplication, QWidget
+
+from app.ui.style import THEMES, _build_custom_qss
+from app.ui.toolbox_panel import ToolboxPanel
+
+
+_app = QApplication.instance() or QApplication([])
+
+
+class _EmptyRegistry:
+    def get_all(self) -> list:
+        return []
+
+
+CANVAS_SELECTORS = (
+    "#chatInterface",
+    "#notesInterface",
+    "#toolboxInterface",
+    "#chatArea",
+    "#noteEditorPanel",
+    "#toolDetailPanel",
+    "#sessionPanel",
+    "#noteListPanel",
+    "#toolListPanel",
+)
+LIST_SELECTORS = ("#sessionList", "#noteList", "#toolList")
+
+
+def _background_for(qss: str, selector: str) -> str | None:
+    qss = re.sub(r"/\*.*?\*/", "", qss, flags=re.DOTALL)
+    background = None
+    for selectors, declarations in re.findall(r"([^{}]+)\{([^{}]*)\}", qss):
+        if selector not in (part.strip() for part in selectors.split(",")):
+            continue
+        for match in re.finditer(
+            r"(?:^|;)\s*background(?:-color)?\s*:\s*([^;]+)", declarations
+        ):
+            background = match.group(1).strip()
+    return background
+
+
+@pytest.mark.parametrize("theme", THEMES.values(), ids=THEMES.keys())
+def test_primary_tab_surfaces_share_theme_canvas_color(theme: dict) -> None:
+    qss = _build_custom_qss(theme)
+
+    assert {
+        selector: _background_for(qss, selector)
+        for selector in CANVAS_SELECTORS
+    } == {selector: theme["surface_solid"] for selector in CANVAS_SELECTORS}
+
+
+@pytest.mark.parametrize("theme", THEMES.values(), ids=THEMES.keys())
+def test_primary_tab_lists_inherit_their_canvas_color(theme: dict) -> None:
+    qss = _build_custom_qss(theme)
+
+    assert {
+        selector: _background_for(qss, selector)
+        for selector in LIST_SELECTORS
+    } == {selector: "transparent" for selector in LIST_SELECTORS}
+
+
+def test_tool_detail_panel_is_bound_to_canvas_selector() -> None:
+    panel = ToolboxPanel(_EmptyRegistry())
+
+    assert panel.findChild(QWidget, "toolDetailPanel") is not None


### PR DESCRIPTION
## Summary

Improve chat interaction reliability, streaming rendering, and message-level actions while tightening local tool security boundaries and aligning the primary tab surfaces across all themes.

## Changes

### Chat interaction and lifecycle

- add copy, regenerate, and edit actions for individual messages
- preserve edit state and support cancel/submit behavior in the input widget
- harden message lifecycle handling across regeneration, errors, and cancellation
- repair reading-session context handling and preserve tool error messages

### Streaming and rendering

- smooth incremental message rendering and scrolling behavior
- reduce unnecessary rich-text re-rendering during streaming
- add regression coverage for message bubbles, scrolling, and lifecycle edge cases

### Tool security

- keep `read_file` access inside the configured workspace boundary
- reject IPv4-mapped private addresses in URL fetching SSRF validation

### Theme consistency

- use the same themed surface for chat, notes, and workshop content areas
- align the corresponding session, note, and tool lists
- cover every configured theme with QSS consistency tests

## Files Changed

- **Core:** turn context handling
- **Tools:** URL SSRF validation and workspace file boundary checks
- **UI:** chat controller, message rendering, input behavior, main window wiring, theme styles, and workshop detail surface
- **Localization:** English and Chinese action labels
- **Tests:** chat lifecycle, input editing, message rendering, tool security boundaries, and theme consistency

## Testing

- `uv run python scripts/check_repo.py`
- `uv run pytest -q` — 316 tests passed locally

## Related Issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
