### PR TITLE
ci: automate Windows draft releases

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -1,33 +1,216 @@
 name: package-windows
 
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: package-windows-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  pyinstaller:
+  build:
     runs-on: windows-latest
+    outputs:
+      version: ${{ steps.metadata.outputs.version }}
 
     env:
       LITELLM_LOCAL_MODEL_COST_MAP: 'True'
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag points to main
+        if: github.event_name == 'push'
+        shell: pwsh
+        run: |
+          git fetch origin main --quiet
+          $fetchExitCode = $LASTEXITCODE
+          if ($fetchExitCode -ne 0) {
+            throw "Failed to fetch origin/main before verifying the release tag."
+          }
+          git merge-base --is-ancestor $env:GITHUB_SHA origin/main
+          if ($LASTEXITCODE -ne 0) {
+            throw "Release tag $env:GITHUB_REF_NAME does not point to a commit on origin/main."
+          }
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: '3.12'
 
-      - name: Install packaging dependencies
+      - name: Install locked dependencies
         run: |
-          python -m pip install --upgrade pip uv
-          uv sync --extra build --frozen
+          python -m pip install uv==0.11.26
+          uv sync --locked --extra dev --extra build
+
+      - name: Validate release metadata
+        id: metadata
+        shell: pwsh
+        run: |
+          $arguments = @(
+            '--root', '.',
+            '--notes-output', 'release-notes.md',
+            '--github-output', $env:GITHUB_OUTPUT
+          )
+          if ($env:GITHUB_EVENT_NAME -eq 'push') {
+            $arguments += @('--tag', $env:GITHUB_REF_NAME)
+          }
+          uv run python scripts/release_metadata.py @arguments
+
+      - name: Run repository checks
+        run: uv run python scripts/check_repo.py
+
+      - name: Run tests
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: uv run python -m pytest -q
 
       - name: Build onefile executable
         run: uv run python -m PyInstaller --clean --noconfirm Nemo_Assistant.spec
 
-      - name: Upload executable
-        uses: actions/upload-artifact@v7
+      - name: Assemble release archive
+        shell: pwsh
+        env:
+          RELEASE_VERSION: ${{ steps.metadata.outputs.version }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $packageDir = 'release/package'
+          $archiveDir = 'release'
+          New-Item -ItemType Directory -Force $packageDir | Out-Null
+
+          $executable = 'dist/Nemo Assistant.exe'
+          if (-not (Test-Path $executable) -or (Get-Item $executable).Length -eq 0) {
+            throw "PyInstaller did not produce a non-empty executable."
+          }
+
+          Copy-Item $executable "$packageDir/Nemo Assistant.exe"
+          Copy-Item 'LICENSE' $packageDir
+          Copy-Item 'THIRD_PARTY_NOTICES.md' $packageDir
+          Copy-Item 'DEPENDENCY_LICENSES.md' $packageDir
+          Copy-Item 'README.md' $packageDir
+          uv run pip-licenses --with-license-file --format=markdown > "$packageDir/DEPENDENCY_LICENSES-FULL.md"
+
+          $zipPath = "$archiveDir/Nemo-Assistant-v$env:RELEASE_VERSION-Windows-x64.zip"
+          Compress-Archive -Path "$packageDir/*" -DestinationPath $zipPath -CompressionLevel Optimal
+
+          $expectedEntries = @(
+            'Nemo Assistant.exe',
+            'LICENSE',
+            'THIRD_PARTY_NOTICES.md',
+            'DEPENDENCY_LICENSES.md',
+            'DEPENDENCY_LICENSES-FULL.md',
+            'README.md'
+          )
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          $archive = [System.IO.Compression.ZipFile]::OpenRead((Resolve-Path $zipPath))
+          try {
+            $actualEntries = @($archive.Entries | ForEach-Object { $_.FullName })
+          } finally {
+            $archive.Dispose()
+          }
+          if (Compare-Object $expectedEntries $actualEntries) {
+            throw "Release archive contains unexpected or missing files: $($actualEntries -join ', ')"
+          }
+
+          $hash = (Get-FileHash $zipPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          "$hash  $(Split-Path $zipPath -Leaf)" | Set-Content 'release/SHA256SUMS.txt' -Encoding ascii
+
+          $notes = Get-Content 'release-notes.md' -Raw
+          @"
+          # Nemo Assistant v$env:RELEASE_VERSION
+
+          $notes
+          ## Download
+
+          Download `Nemo-Assistant-v$env:RELEASE_VERSION-Windows-x64.zip`, verify it with `SHA256SUMS.txt`, and extract it on Windows 10/11.
+
+          The archive includes the executable, project license, third-party notices, and dependency license inventories. This build is unsigned; Windows SmartScreen may show a warning on first launch.
+          "@ | Set-Content 'release/release-notes.md' -Encoding utf8
+
+      - name: Upload release candidate
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: nemo-assistant-windows
-          path: "dist/Nemo Assistant.exe"
+          name: nemo-assistant-release-${{ steps.metadata.outputs.version }}-${{ github.run_attempt }}
+          path: |
+            release/*.zip
+            release/SHA256SUMS.txt
+            release/release-notes.md
+          if-no-files-found: error
+          retention-days: 14
+
+  draft-release:
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      RELEASE_TAG: ${{ github.ref_name }}
+      RELEASE_SHA: ${{ github.sha }}
+      RELEASE_VERSION: ${{ needs.build.outputs.version }}
+
+    steps:
+      - name: Download release candidate
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        with:
+          name: nemo-assistant-release-${{ needs.build.outputs.version }}-${{ github.run_attempt }}
+          path: release-assets
+
+      - name: Create or update draft release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          notes_file="release-assets/release-notes.md"
+          zip_asset="release-assets/Nemo-Assistant-v${RELEASE_VERSION}-Windows-x64.zip"
+          checksum_asset="release-assets/SHA256SUMS.txt"
+
+          tag_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq .sha)"
+          if [[ "$tag_sha" != "$RELEASE_SHA" ]]; then
+            echo "Release tag moved from $RELEASE_SHA to $tag_sha during the workflow." >&2
+            exit 1
+          fi
+
+          release_json="$RUNNER_TEMP/release.json"
+          release_error="$RUNNER_TEMP/release-error.log"
+          if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" >"$release_json" 2>"$release_error"; then
+            if [[ "$(jq -r .draft "$release_json")" != "true" ]]; then
+              echo "Refusing to modify already-published release $RELEASE_TAG" >&2
+              exit 1
+            fi
+            while IFS= read -r asset_name; do
+              if [[ "$asset_name" != "$(basename "$zip_asset")" && "$asset_name" != "$(basename "$checksum_asset")" ]]; then
+                echo "Draft release contains unexpected asset: $asset_name" >&2
+                exit 1
+              fi
+            done < <(jq -r '.assets[].name' "$release_json")
+
+            gh release upload "$RELEASE_TAG" "$zip_asset" "$checksum_asset" \
+              --repo "$GITHUB_REPOSITORY" \
+              --clobber
+            gh release edit "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --draft \
+              --title "Nemo Assistant v${RELEASE_VERSION}" \
+              --notes-file "$notes_file"
+          elif grep -q '(HTTP 404)' "$release_error"; then
+            gh release create "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --draft \
+              --title "Nemo Assistant v${RELEASE_VERSION}" \
+              --notes-file "$notes_file" \
+              "$zip_asset" "$checksum_asset"
+          else
+            cat "$release_error" >&2
+            exit 1
+          fi

--- a/docs/en/release-checklist.md
+++ b/docs/en/release-checklist.md
@@ -4,11 +4,52 @@
 
 Use this checklist before publishing a GitHub release or attaching a Windows executable.
 
+## When to Release
+
+Do not release on a fixed calendar date. Release when a coherent user-facing
+milestone is ready and the previous release's known blockers are closed.
+
+For this project, prefer a small release every few meaningful improvements:
+
+- `patch` (`0.1.1`): a backward-compatible bug fix or packaging correction.
+- `minor` (`0.2.0`): a user-visible feature set or a meaningful workflow improvement.
+- `major` (`1.0.0`): a stable compatibility and support commitment.
+
+After `v0.1.0`, the chat reliability fixes and rendering performance work form a
+reasonable `v0.2.0` candidate once the packaged executable passes the Windows
+smoke check below.
+
+## Automated Release Flow
+
+1. Create a release PR from `main` that updates `pyproject.toml`, `uv.lock`, and
+   the dated section in `CHANGELOG.md`.
+2. Merge the PR after the normal `tests` check passes.
+3. Create and push an annotated tag from the merged commit, for example:
+
+   ```bash
+   git switch main
+   git pull --ff-only
+   git tag -a v0.2.0 -m "Release v0.2.0"
+   git push origin v0.2.0
+   ```
+
+4. The `package-windows` workflow validates the tag and version metadata, runs
+   repository checks and tests, builds the executable, creates a license-aware
+   ZIP and SHA256 file, and creates a GitHub **Draft Release**.
+5. Download the assets from that Draft Release, complete the Windows and license
+   checks below, then click **Publish release**. The workflow does not publish
+   a Draft automatically.
+
+The workflow accepts strict stable tags in the `vMAJOR.MINOR.PATCH` form. A
+manual run is useful for testing a candidate package, but it does not create a
+Release. Do not move or delete a tag after a failed or published release;
+prepare a new patch version instead.
+
 ## Source Release
 
 - Run `uv sync --extra dev --frozen`.
 - Run `uv run python scripts/check_repo.py`.
-- Run `uv run pytest -q`.
+- Run `uv run python -m pytest -q`.
 - Confirm `git status --short` contains only intended release changes.
 - Update `CHANGELOG.md`.
 

--- a/docs/zh/release-checklist.md
+++ b/docs/zh/release-checklist.md
@@ -4,11 +4,47 @@
 
 在发布 GitHub Release 或附上 Windows 可执行文件之前，请对照本清单检查。
 
+## 什么时候发布
+
+不按固定日历日期发布。当一组完整的用户可感知改进已经就绪，并且上个版本的已知阻断问题均已解决时发布。
+
+本项目适合累积少量有意义的改进后发布：
+
+- `patch`（`0.1.1`）：向后兼容的错误修复或打包修正。
+- `minor`（`0.2.0`）：一组用户可见功能或显著的工作流改进。
+- `major`（`1.0.0`）：对稳定兼容性和支持范围作出承诺。
+
+`v0.1.0` 之后的聊天可靠性修复和渲染性能优化已经构成合理的
+`v0.2.0` 候选；打包后的可执行文件通过下述 Windows 冒烟检查后即可发布。
+
+## 自动发布流程
+
+1. 从 `main` 创建发布 PR，同时更新 `pyproject.toml`、`uv.lock` 和
+   `CHANGELOG.md` 中带日期的版本章节。
+2. 常规 `tests` 检查通过后合并 PR。
+3. 在合并后的提交上创建并推送附注标签，例如：
+
+   ```bash
+   git switch main
+   git pull --ff-only
+   git tag -a v0.2.0 -m "Release v0.2.0"
+   git push origin v0.2.0
+   ```
+
+4. `package-windows` 工作流会校验标签和版本元数据、运行仓库检查与测试、
+   构建可执行文件、生成包含许可证材料的 ZIP 和 SHA256 文件，并创建
+   GitHub **Draft Release**。
+5. 从 Draft Release 下载最终产物，完成下方 Windows 和许可证检查，再点击
+   **Publish release**。工作流不会自动公开草稿。
+
+工作流仅接受 `vMAJOR.MINOR.PATCH` 格式的稳定版标签。手动运行可用于测试候选包，
+但不会创建 Release。失败或已公开的版本不得移动或删除标签，应准备新的 patch 版本。
+
 ## 源码发布
 
 - 运行 `uv sync --extra dev --frozen`。
 - 运行 `uv run python scripts/check_repo.py`。
-- 运行 `uv run pytest -q`。
+- 运行 `uv run python -m pytest -q`。
 - 确认 `git status --short` 只包含本次发布应有的改动。
 - 更新 `CHANGELOG.md`。
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository maintenance scripts."""

--- a/scripts/release_metadata.py
+++ b/scripts/release_metadata.py
@@ -1,0 +1,170 @@
+"""Validate release metadata and extract notes for GitHub Releases."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TAG_PATTERN = re.compile(r"^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+RELEASE_HEADING_PATTERN = re.compile(
+    r"^## \[(?P<version>[^]]+)] - (?P<date>\d{4}-\d{2}-\d{2})\s*$",
+    re.MULTILINE,
+)
+
+
+def _project_version(root: Path) -> str:
+    with (root / "pyproject.toml").open("rb") as file:
+        data = tomllib.load(file)
+    return str(data["project"]["version"])
+
+
+def _locked_project_version(root: Path) -> str:
+    with (root / "uv.lock").open("rb") as file:
+        data = tomllib.load(file)
+
+    packages = data.get("package", [])
+    if not isinstance(packages, list):
+        raise ValueError("uv.lock package entries must be an array")
+
+    matching_packages: list[dict[str, object]] = []
+    for package in packages:
+        if not isinstance(package, dict):
+            raise ValueError("uv.lock package entry must be a table")
+        source = package.get("source", {})
+        if not isinstance(source, dict):
+            raise ValueError("uv.lock package source must be a table")
+        if package.get("name") == "nemo-assistant" and source.get("editable") == ".":
+            matching_packages.append(package)
+
+    if len(matching_packages) != 1:
+        raise ValueError("uv.lock must contain one editable nemo-assistant package")
+    return str(matching_packages[0]["version"])
+
+
+def extract_release_notes(root: Path, version: str) -> str:
+    changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+    headings = list(RELEASE_HEADING_PATTERN.finditer(changelog))
+    matches = [
+        (index, heading)
+        for index, heading in enumerate(headings)
+        if heading.group("version") == version
+    ]
+    if len(matches) != 1:
+        return ""
+
+    index, heading = matches[0]
+    end = headings[index + 1].start() if index + 1 < len(headings) else len(changelog)
+    return changelog[heading.end() : end].strip() + "\n"
+
+
+def _release_heading_errors(
+    headings: list[re.Match[str]], version: str
+) -> list[str]:
+    matching_headings = [
+        heading for heading in headings if heading.group("version") == version
+    ]
+    errors: list[str] = []
+    for heading in matching_headings:
+        release_date = heading.group("date")
+        try:
+            date.fromisoformat(release_date)
+        except ValueError:
+            errors.append(
+                f"CHANGELOG.md release date {release_date} for version "
+                f"{version} is invalid"
+            )
+    if not matching_headings:
+        errors.append(
+            f"CHANGELOG.md has no dated release heading for version {version}"
+        )
+    elif len(matching_headings) > 1:
+        errors.append(
+            f"CHANGELOG.md has multiple dated release headings for version {version}"
+        )
+    return errors
+
+
+def validate_release(root: Path, tag: str) -> list[str]:
+    match = TAG_PATTERN.fullmatch(tag)
+    if match is None:
+        return [f"invalid release tag {tag!r}; expected vMAJOR.MINOR.PATCH"]
+
+    version = tag.removeprefix("v")
+    errors: list[str] = []
+
+    project_version = _project_version(root)
+    if project_version != version:
+        errors.append(
+            f"tag version {version} does not match pyproject.toml version "
+            f"{project_version}"
+        )
+
+    lock_version = _locked_project_version(root)
+    if lock_version != version:
+        errors.append(
+            f"tag version {version} does not match uv.lock project version "
+            f"{lock_version}"
+        )
+
+    changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+    headings = list(RELEASE_HEADING_PATTERN.finditer(changelog))
+    heading_errors = _release_heading_errors(headings, version)
+    errors.extend(heading_errors)
+    if not heading_errors and not extract_release_notes(root, version).strip():
+        errors.append(f"CHANGELOG.md release notes for version {version} are empty")
+
+    return errors
+
+
+def _write_github_output(path: Path, version: str) -> None:
+    with path.open("a", encoding="utf-8") as file:
+        file.write(f"version={version}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tag",
+        help="Release tag. Defaults to v<project.version> for candidate builds.",
+    )
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--notes-output", type=Path)
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args()
+
+    try:
+        project_version = _project_version(args.root)
+        tag = args.tag or f"v{project_version}"
+        errors = validate_release(args.root, tag)
+        if errors:
+            for error in errors:
+                print(f"ERROR: {error}", file=sys.stderr)
+            return 1
+
+        version = tag.removeprefix("v")
+        if args.notes_output:
+            args.notes_output.write_text(
+                extract_release_notes(args.root, version), encoding="utf-8"
+            )
+        if args.github_output:
+            _write_github_output(args.github_output, version)
+    except (KeyError, OSError, TypeError, ValueError, tomllib.TOMLDecodeError) as exc:
+        print(f"ERROR: could not validate release metadata: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Release metadata is valid for {tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,0 +1,169 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.release_metadata import extract_release_notes, main, validate_release
+
+
+def _write_release_files(
+    root: Path,
+    *,
+    project_version: str = "1.2.3",
+    lock_version: str = "1.2.3",
+    changelog: str | None = None,
+) -> Path:
+    (root / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "nemo-assistant"',
+                f'version = "{project_version}"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (root / "uv.lock").write_text(
+        "\n".join(
+            [
+                "version = 1",
+                "revision = 1",
+                "",
+                "[[package]]",
+                'name = "nemo-assistant"',
+                f'version = "{lock_version}"',
+                'source = { editable = "." }',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (root / "CHANGELOG.md").write_text(
+        changelog
+        or """# Changelog
+
+## [Unreleased]
+
+## [1.2.3] - 2026-07-19
+
+### Added
+
+- Automated release validation.
+
+## [1.2.2] - 2026-07-01
+
+- Previous release.
+""",
+        encoding="utf-8",
+    )
+    return root
+
+
+def test_accepts_matching_release_metadata(tmp_path: Path) -> None:
+    root = _write_release_files(tmp_path)
+
+    assert validate_release(root, "v1.2.3") == []
+
+
+@pytest.mark.parametrize(
+    "tag",
+    ["", "1.2.3", "v1.2", "v1.2.3.4", "v01.2.3", "release-1.2.3"],
+)
+def test_rejects_invalid_release_tag(tmp_path: Path, tag: str) -> None:
+    root = _write_release_files(tmp_path)
+
+    assert validate_release(root, tag) == [
+        f"invalid release tag {tag!r}; expected vMAJOR.MINOR.PATCH"
+    ]
+
+
+def test_rejects_project_version_mismatch(tmp_path: Path) -> None:
+    root = _write_release_files(tmp_path, project_version="1.2.4")
+
+    assert validate_release(root, "v1.2.3") == [
+        "tag version 1.2.3 does not match pyproject.toml version 1.2.4"
+    ]
+
+
+def test_rejects_lock_version_mismatch(tmp_path: Path) -> None:
+    root = _write_release_files(tmp_path, lock_version="1.2.4")
+
+    assert validate_release(root, "v1.2.3") == [
+        "tag version 1.2.3 does not match uv.lock project version 1.2.4"
+    ]
+
+
+def test_rejects_missing_changelog_release(tmp_path: Path) -> None:
+    root = _write_release_files(
+        tmp_path,
+        changelog="# Changelog\n\n## [Unreleased]\n\nMentions 1.2.3 only.\n",
+    )
+
+    assert validate_release(root, "v1.2.3") == [
+        "CHANGELOG.md has no dated release heading for version 1.2.3"
+    ]
+
+
+def test_rejects_empty_changelog_release(tmp_path: Path) -> None:
+    root = _write_release_files(
+        tmp_path,
+        changelog="""# Changelog
+
+## [1.2.3] - 2026-07-19
+
+## [1.2.2] - 2026-07-01
+
+- Previous release.
+""",
+    )
+
+    assert validate_release(root, "v1.2.3") == [
+        "CHANGELOG.md release notes for version 1.2.3 are empty"
+    ]
+
+
+def test_rejects_invalid_changelog_date(tmp_path: Path) -> None:
+    root = _write_release_files(
+        tmp_path,
+        changelog="""# Changelog
+
+## [1.2.3] - 2026-02-30
+
+- Impossible date.
+""",
+    )
+
+    assert validate_release(root, "v1.2.3") == [
+        "CHANGELOG.md release date 2026-02-30 for version 1.2.3 is invalid"
+    ]
+
+
+def test_cli_handles_malformed_lock_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = _write_release_files(tmp_path)
+    (root / "uv.lock").write_text(
+        """version = 1
+revision = 1
+
+[[package]]
+name = "nemo-assistant"
+version = "1.2.3"
+source = "invalid"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "sys.argv", ["release_metadata.py", "--root", str(root), "--tag", "v1.2.3"]
+    )
+
+    assert main() == 1
+    assert "uv.lock package source must be a table" in capsys.readouterr().err
+
+
+def test_extracts_only_requested_release_notes(tmp_path: Path) -> None:
+    root = _write_release_files(tmp_path)
+
+    assert extract_release_notes(root, "1.2.3") == (
+        "### Added\n\n- Automated release validation.\n"
+    )

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "package-windows.yml"
+
+
+def test_release_workflow_builds_draft_release_from_version_tag() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "tags:" in workflow
+    assert "'v*'" in workflow
+    assert "scripts/release_metadata.py" in workflow
+    assert "uv run python scripts/check_repo.py" in workflow
+    assert "uv run python -m pytest -q" in workflow
+    assert "DEPENDENCY_LICENSES.md" in workflow
+    assert "THIRD_PARTY_NOTICES.md" in workflow
+    assert "SHA256SUMS.txt" in workflow
+    assert "release/release-notes.md" in workflow
+    assert 'notes_file="release-assets/release-notes.md"' in workflow
+    assert '--notes-file "$notes_file"' in workflow
+    assert 'gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG"' in workflow
+    assert 'gh release create "$RELEASE_TAG"' in workflow
+    assert '--repo "$GITHUB_REPOSITORY"' in workflow
+    assert "--draft" in workflow
+    assert "contents: write" in workflow
+    assert "uv sync --locked --extra dev --extra build" in workflow
+    assert "$fetchExitCode = $LASTEXITCODE" in workflow
+    assert "github.run_attempt" in workflow
+    assert "RELEASE_SHA" in workflow
+    assert "commits/$RELEASE_TAG" in workflow


### PR DESCRIPTION
## Summary

Automate Windows release candidates from version tags while retaining a manual publication gate for real desktop smoke testing and license review. The workflow validates release metadata, runs tests, packages a license-aware archive, and creates a GitHub Draft Release.

## Related issue

None.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [x] Documentation
- [x] Other: CI and release automation

## How it was verified

- `uv run python scripts/check_repo.py`
- `uv run python -m pytest -q`
- `uv run python -m pytest -q tests/test_release_metadata.py tests/test_release_workflow.py --cov=scripts.release_metadata --cov-report=term-missing --cov-fail-under=80`
- Current `v0.1.0` metadata validated through the release CLI
- GitHub Actions runner packaging and real Windows GUI smoke testing remain publication gates

- [x] `pytest -q` passes (with `QT_QPA_PLATFORM=offscreen` set)
- [x] New / changed functionality has corresponding tests
- [ ] Manually verified the related UI / interaction

## Checklist

- [x] Commit messages are in English and follow Conventional Commits
- [x] No personal config (`config/app_config.json`) or secrets committed
- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
